### PR TITLE
trying to start fixing pop/case matching problems

### DIFF
--- a/casesPopbyCounty.csv
+++ b/casesPopbyCounty.csv
@@ -1,3142 +1,3142 @@
-State,County,Cases,County,Population
-Alabama,Autauga,2580,Autauga,"55,869"
-Alabama,Baldwin,8038,Baldwin,"223,234"
-Alabama,Barbour,1151,Barbour,"24,686"
-Alabama,Bibb,1024,Bibb,"22,394"
-Alabama,Blount,2704,Blount,"57,826"
-Alabama,Bullock,684,Bullock,"10,101"
-Alabama,Butler,1120,Butler,"19,448"
-Alabama,Calhoun,5896,Calhoun,"113,605"
-Alabama,Chambers,1663,Chambers,"33,254"
-Alabama,Cherokee,959,Cherokee,"26,196"
-Alabama,Chilton,2125,Chilton,"44,428"
-Alabama,Choctaw,413,Choctaw,"12,589"
-Alabama,Clarke,1536,Clarke,"23,622"
-Alabama,Clay,876,Clay,"13,235"
-Alabama,Cleburne,705,Cleburne,"14,910"
-Alabama,Coffee,2265,Coffee,"52,342"
-Alabama,Colbert,2880,Colbert,"55,241"
-Alabama,Conecuh,667,Conecuh,"12,067"
-Alabama,Coosa,299,Coosa,"10,663"
-Alabama,Covington,2104,Covington,"37,049"
-Alabama,Crenshaw,698,Crenshaw,"13,772"
-Alabama,Cullman,3998,Cullman,"83,768"
-Alabama,Dale,2230,Dale,"49,172"
-Alabama,Dallas,2168,Dallas,"37,196"
-Alabama,DeKalb,4506,DeKalb,"71,513"
-Alabama,Elmore,3820,Elmore,"81,209"
-Alabama,Escambia,1934,Escambia,"36,633"
-Alabama,Etowah,5741,Etowah,"102,268"
-Alabama,Fayette,800,Fayette,"16,302"
-Alabama,Franklin,2394,Franklin,"31,362"
-Alabama,Geneva,1145,Geneva,"26,271"
-Alabama,Greene,394,Greene,"8,111"
-Alabama,Hale,907,Hale,"14,651"
-Alabama,Henry,833,Henry,"17,205"
-Alabama,Houston,4945,Houston,"105,882"
-Alabama,Jackson,2837,Jackson,"51,626"
-Alabama,Jefferson,29626,Jefferson,"658,573"
-Alabama,Lamar,601,Lamar,"13,805"
-Alabama,Lauderdale,3653,Lauderdale,"92,729"
-Alabama,Lawrence,1179,Lawrence,"32,924"
-Alabama,Lee,7421,Lee,"164,542"
-Alabama,Limestone,3901,Limestone,"98,915"
-Alabama,Lowndes,771,Lowndes,"9,726"
-Alabama,Macon,684,Macon,"18,068"
-Alabama,Madison,11958,Madison,"372,909"
-Alabama,Marengo,1159,Marengo,"18,863"
-Alabama,Marion,1320,Marion,"29,709"
-Alabama,Marshall,5660,Marshall,"96,774"
-Alabama,Mobile,19090,Mobile,"413,210"
-Alabama,Monroe,758,Monroe,"20,733"
-Alabama,Montgomery,11903,Montgomery,"226,486"
-Alabama,Morgan,5913,Morgan,"119,679"
-Alabama,Perry,656,Perry,"8,923"
-Alabama,Pickens,1119,Pickens,"19,930"
-Alabama,Pike,1529,Pike,"33,114"
-Alabama,Randolph,972,Randolph,"22,722"
-Alabama,Russell,2126,Russell,"57,961"
-Alabama,Shelby,9537,StClair,"89,512"
-Alabama,St. Clair,3891,Shelby,"217,702"
-Alabama,Sumter,547,Sumter,"12,427"
-Alabama,Talladega,3292,Talladega,"79,978"
-Alabama,Tallapoosa,1668,Tallapoosa,"40,367"
-Alabama,Tuscaloosa,12274,Tuscaloosa,"209,355"
-Alabama,Walker,3424,Walker,"63,521"
-Alabama,Washington,891,Washington,"16,326"
-Alabama,Wilcox,619,Wilcox,"10,373"
-Alabama,Winston,1192,Winston,"23,629"
-Alaska,Aleutians East,21,AleutiansEastBoroughAlaska,"3,337"
-Alaska,Aleutians West,106,AleutiansWestCensusAreaAlaska,"5,634"
-Alaska,Anchorage,14063,AnchorageMunicipalityAlaska,"288,000"
-Alaska,Bethel,1085,BethelCensusAreaAlaska,"18,386"
-Alaska,Bristol Bay plus Lake and Peninsula,141,BristolBayBoroughAlaska,836
-Alaska,Denali,40,DenaliBoroughAlaska,"2,097"
-Alaska,Dillingham,90,DillinghamCensusAreaAlaska,"4,916"
-Alaska,Fairbanks North Star,3034,FairbanksNorthStarBoroughAlaska,"96,849"
-Alaska,Haines,16,HainesBoroughAlaska,"2,530"
-Alaska,Hoonah-Angoon,0,HoonahAngoonCensusAreaAlaska,"2,148"
-Alaska,Juneau,776,JuneauCityandBoroughAlaska,"31,974"
-Alaska,Kenai Peninsula,2009,KenaiPeninsulaBoroughAlaska,"58,708"
-Alaska,Ketchikan Gateway,183,KetchikanGatewayBoroughAlaska,"13,901"
-Alaska,Kodiak Island,203,KodiakIslandBoroughAlaska,"12,998"
-Alaska,Kusilvak,374,KusilvakCensusAreaAlaska,"8,314"
-Alaska,Matanuska-Susitna,2504,LakeandPeninsulaBoroughAlaska,"1,592"
-Alaska,Nome,178,MatanuskaSusitnaBoroughAlaska,"108,317"
-Alaska,North Slope,403,NomeCensusAreaAlaska,"10,004"
-Alaska,Northwest Arctic,326,NorthSlopeBoroughAlaska,"9,832"
-Alaska,Petersburg,23,NorthwestArcticBoroughAlaska,"7,621"
-Alaska,Prince of Wales-Hyder,46,PetersburgBoroughAlaska,"3,266"
-Alaska,Sitka,145,PrinceofWalesHyderCensusAreaAlaska,"6,203"
-Alaska,Skagway,8,SitkaCityandBoroughAlaska,"8,493"
-Alaska,Southeast Fairbanks,206,SkagwayMunicipalityAlaska,"1,183"
-Alaska,Unassigned,118,SoutheastFairbanksCensusAreaAlaska,"6,893"
-Alaska,Valdez-Cordova,232,ValdezCordovaCensusAreaAlaska,"9,202"
-Alaska,Wrangell,20,WrangellCityandBoroughAlaska,"2,502"
-Alaska,Yakutat,44,YakutatCityandBoroughAlaska,579
-Alaska,Yukon-Koyukuk,150,YukonKoyukukCensusAreaAlaska,"5,230"
-Arizona,Apache,4741,Apache,"71,887"
-Arizona,Cochise,3020,Cochise,"125,922"
-Arizona,Coconino,6765,Coconino,"143,476"
-Arizona,Gila,2514,Gila,"54,018"
-Arizona,Graham,1815,Graham,"38,837"
-Arizona,Greenlee,154,Greenlee,"9,498"
-Arizona,La Paz,740,LaPaz,"21,108"
-Arizona,Maricopa,185580,Maricopa,"4,485,414"
-Arizona,Mohave,5482,Mohave,"212,181"
-Arizona,Navajo,7444,Navajo,"110,924"
-Arizona,Pima,34985,Pima,"1,047,279"
-Arizona,Pinal,14851,Pinal,"462,789"
-Arizona,Santa Cruz,3468,SantaCruz,"46,498"
-Arizona,Yavapai,4095,Yavapai,"235,099"
-Arizona,Yuma,16042,Yuma,"213,787"
-Arkansas,Arkansas,894,Arkansas,"17,486"
-Arkansas,Ashley,724,Ashley,"19,657"
-Arkansas,Baxter,1216,Baxter,"41,932"
-Arkansas,Benton,10906,Benton,"279,141"
-Arkansas,Boone,1522,Boone,"37,432"
-Arkansas,Bradley,420,Bradley,"10,763"
-Arkansas,Calhoun,125,Calhoun,"5,189"
-Arkansas,Carroll,1259,Carroll,"28,380"
-Arkansas,Chicot,1119,Chicot,"10,118"
-Arkansas,Clark,734,Clark,"22,320"
-Arkansas,Clay,755,Clay,"14,551"
-Arkansas,Cleburne,635,Cleburne,"24,919"
-Arkansas,Cleveland,324,Cleveland,"7,956"
-Arkansas,Columbia,952,Columbia,"23,457"
-Arkansas,Conway,582,Conway,"20,846"
-Arkansas,Craighead,6423,Craighead,"110,332"
-Arkansas,Crawford,2818,Crawford,"63,257"
-Arkansas,Crittenden,3043,Crittenden,"47,955"
-Arkansas,Cross,740,Cross,"16,419"
-Arkansas,Dallas,255,Dallas,"7,009"
-Arkansas,Desha,505,Desha,"11,361"
-Arkansas,Drew,558,Drew,"18,219"
-Arkansas,Faulkner,4342,Faulkner,"126,007"
-Arkansas,Franklin,698,Franklin,"17,715"
-Arkansas,Fulton,488,Fulton,"12,477"
-Arkansas,Garland,3416,Garland,"99,386"
-Arkansas,Grant,519,Grant,"18,265"
-Arkansas,Greene,2482,Greene,"45,325"
-Arkansas,Hempstead,790,Hempstead,"21,532"
-Arkansas,Hot Spring,2729,HotSpring,"33,771"
-Arkansas,Howard,759,Howard,"13,202"
-Arkansas,Independence,1923,Independence,"37,825"
-Arkansas,Izard,940,Izard,"13,629"
-Arkansas,Jackson,1479,Jackson,"16,719"
-Arkansas,Jefferson,4929,Jefferson,"66,824"
-Arkansas,Johnson,1191,Johnson,"26,578"
-Arkansas,Lafayette,248,Lafayette,"6,624"
-Arkansas,Lawrence,1070,Lawrence,"16,406"
-Arkansas,Lee,1148,Lee,"8,857"
-Arkansas,Lincoln,2382,Lincoln,"13,024"
-Arkansas,Little River,601,LittleRiver,"12,259"
-Arkansas,Logan,822,Logan,"21,466"
-Arkansas,Lonoke,2423,Lonoke,"73,309"
-Arkansas,Madison,546,Madison,"16,576"
-Arkansas,Marion,365,Marion,"16,694"
-Arkansas,Miller,2017,Miller,"43,257"
-Arkansas,Mississippi,2960,Mississippi,"40,651"
-Arkansas,Monroe,283,Monroe,"6,701"
-Arkansas,Montgomery,235,Montgomery,"8,986"
-Arkansas,Nevada,416,Nevada,"8,252"
-Arkansas,Newton,397,Newton,"7,753"
-Arkansas,Ouachita,579,Ouachita,"23,382"
-Arkansas,Perry,222,Perry,"10,455"
-Arkansas,Phillips,874,Phillips,"17,782"
-Arkansas,Pike,344,Pike,"10,718"
-Arkansas,Poinsett,1557,Poinsett,"23,528"
-Arkansas,Polk,673,Polk,"19,964"
-Arkansas,Pope,3413,Pope,"64,072"
-Arkansas,Prairie,335,Prairie,"8,062"
-Arkansas,Pulaski,15255,Pulaski,"391,911"
-Arkansas,Randolph,907,Randolph,"17,958"
-Arkansas,Saline,4170,StFrancis,"24,994"
-Arkansas,Scott,323,Saline,"122,437"
-Arkansas,Searcy,268,Scott,"10,281"
-Arkansas,Sebastian,6467,Searcy,"7,881"
-Arkansas,Sevier,1630,Sebastian,"127,827"
-Arkansas,Sharp,604,Sevier,"17,007"
-Arkansas,St. Francis,1959,Sharp,"17,442"
-Arkansas,Stone,439,Stone,"12,506"
-Arkansas,Union,1420,Union,"38,682"
-Arkansas,Van Buren,307,VanBuren,"16,545"
-Arkansas,Washington,14252,Washington,"239,187"
-Arkansas,White,2663,White,"78,753"
-Arkansas,Woodruff,181,Woodruff,"6,320"
-Arkansas,Yell,1563,Yell,"21,341"
-California,Alameda,27223,Alameda,"1,671,329"
-California,Alpine,39,Alpine,"1,129"
-California,Amador,455,Amador,"39,752"
-California,Butte,3580,Butte,"219,186"
-California,Calaveras,417,Calaveras,"45,905"
-California,Colusa,623,Colusa,"21,547"
-California,Contra Costa,21959,ContraCosta,"1,153,526"
-California,Del Norte,259,DelNorte,"27,812"
-California,El Dorado,1899,ElDorado,"192,843"
-California,Fresno,35278,Fresno,"999,101"
-California,Glenn,820,Glenn,"28,393"
-California,Humboldt,730,Humboldt,"135,558"
-California,Imperial,14720,Imperial,"181,215"
-California,Inyo,268,Inyo,"18,039"
-California,Kern,37632,Kern,"900,202"
-California,Kings,9775,Kings,"152,940"
-California,Lake,815,Lake,"64,386"
-California,Lassen,1242,Lassen,"30,573"
-California,Los Angeles,357451,LosAngeles,"10,039,107"
-California,Madera,5714,Madera,"157,327"
-California,Marin,7489,Marin,"258,826"
-California,Mariposa,94,Mariposa,"17,203"
-California,Mendocino,1368,Mendocino,"86,749"
-California,Merced,10884,Merced,"277,680"
-California,Modoc,106,Modoc,"8,841"
-California,Mono,494,Mono,"14,444"
-California,Monterey,13410,Monterey,"434,061"
-California,Napa,2641,Napa,"137,744"
-California,Nevada,948,Nevada,"99,755"
-California,Orange,68336,Orange,"3,175,692"
-California,Placer,5687,Placer,"398,329"
-California,Plumas,165,Plumas,"18,807"
-California,Riverside,78535,Riverside,"2,470,546"
-California,Sacramento,32411,Sacramento,"1,552,058"
-California,San Benito,1694,SanBenito,"62,808"
-California,San Bernardino,81328,SanBernardino,"2,180,085"
-California,San Diego,69231,SanDiego,"3,338,330"
-California,San Francisco,14251,SanFrancisco,"881,549"
-California,San Joaquin,24450,SanJoaquin,"762,148"
-California,San Luis Obispo,5486,SanLuisObispo,"283,111"
-California,San Mateo,12988,SanMateo,"766,573"
-California,Santa Barbara,10768,SantaBarbara,"446,499"
-California,Santa Clara,30025,SantaClara,"1,927,852"
-California,Santa Cruz,3685,SantaCruz,"273,213"
-California,Shasta,3897,Shasta,"180,080"
-California,Sierra,17,Sierra,"3,005"
-California,Siskiyou,466,Siskiyou,"43,539"
-California,Solano,9349,Solano,"447,643"
-California,Sonoma,11316,Sonoma,"494,336"
-California,Stanislaus,19964,Stanislaus,"550,660"
-California,Sutter,2601,Sutter,"96,971"
-California,Tehama,1377,Tehama,"65,084"
-California,Trinity,106,Trinity,"12,285"
-California,Tulare,19553,Tulare,"466,195"
-California,Tuolumne,675,Tuolumne,"54,478"
-California,Ventura,17300,Ventura,"846,006"
-California,Yolo,4050,Yolo,"220,500"
-California,Yuba,1706,Yuba,"78,668"
-Colorado,Adams,25092,Adams,"517,421"
-Colorado,Alamosa,500,Alamosa,"16,233"
-Colorado,Arapahoe,22728,Arapahoe,"656,590"
-Colorado,Archuleta,129,Archuleta,"14,029"
-Colorado,Baca,51,Baca,"3,581"
-Colorado,Bent,57,Bent,"5,577"
-Colorado,Boulder,9503,Boulder,"326,196"
-Colorado,Broomfield,1704,Broomfield,"70,465"
-Colorado,Chaffee,539,Chaffee,"20,356"
-Colorado,Cheyenne,46,Cheyenne,"1,831"
-Colorado,Clear Creek,159,ClearCreek,"9,700"
-Colorado,Conejos,145,Conejos,"8,205"
-Colorado,Costilla,68,Costilla,"3,887"
-Colorado,Crowley,928,Crowley,"6,061"
-Colorado,Custer,55,Custer,"5,068"
-Colorado,Delta,425,Delta,"31,162"
-Colorado,Denver,31073,Denver,"727,211"
-Colorado,Dolores,8,Dolores,"2,055"
-Colorado,Douglas,8457,Douglas,"351,154"
-Colorado,Eagle,2012,Eagle,"55,127"
-Colorado,El Paso,21308,Elbert,"26,729"
-Colorado,Elbert,475,ElPaso,"720,403"
-Colorado,Fremont,1975,Fremont,"47,839"
-Colorado,Garfield,1776,Garfield,"60,061"
-Colorado,Gilpin,75,Gilpin,"6,243"
-Colorado,Grand,259,Grand,"15,734"
-Colorado,Gunnison,429,Gunnison,"17,462"
-Colorado,Hinsdale,6,Hinsdale,820
-Colorado,Huerfano,103,Huerfano,"6,897"
-Colorado,Jackson,14,Jackson,"1,392"
-Colorado,Jefferson,16811,Jefferson,"582,881"
-Colorado,Kiowa,19,Kiowa,"1,406"
-Colorado,Kit Carson,247,KitCarson,"7,097"
-Colorado,La Plata,753,Lake,"8,127"
-Colorado,Lake,224,LaPlata,"56,221"
-Colorado,Larimer,8174,Larimer,"356,899"
-Colorado,Las Animas,152,LasAnimas,"14,506"
-Colorado,Lincoln,108,Lincoln,"5,701"
-Colorado,Logan,1940,Logan,"22,409"
-Colorado,Mesa,4515,Mesa,"154,210"
-Colorado,Mineral,24,Mineral,769
-Colorado,Moffat,202,Moffat,"13,283"
-Colorado,Montezuma,530,Montezuma,"26,183"
-Colorado,Montrose,734,Montrose,"42,758"
-Colorado,Morgan,1377,Morgan,"29,068"
-Colorado,Otero,376,Otero,"18,278"
-Colorado,Ouray,105,Ouray,"4,952"
-Colorado,Park,192,Park,"18,845"
-Colorado,Phillips,158,Phillips,"4,265"
-Colorado,Pitkin,420,Pitkin,"17,767"
-Colorado,Prowers,436,Prowers,"12,172"
-Colorado,Pueblo,6110,Pueblo,"168,424"
-Colorado,Rio Blanco,84,RioBlanco,"6,324"
-Colorado,Rio Grande,188,RioGrande,"11,267"
-Colorado,Routt,500,Routt,"25,638"
-Colorado,Saguache,195,Saguache,"6,824"
-Colorado,San Juan,19,SanJuan,728
-Colorado,San Miguel,174,SanMiguel,"8,179"
-Colorado,Sedgwick,95,Sedgwick,"2,248"
-Colorado,Summit,1242,Summit,"31,011"
-Colorado,Teller,503,Teller,"25,388"
-Colorado,Washington,182,Washington,"4,908"
-Colorado,Weld,11368,Weld,"324,492"
-Colorado,Yuma,284,Yuma,"10,019"
-Connecticut,Fairfield,33648,Fairfield,"943,332"
-Connecticut,Hartford,25182,Hartford,"891,720"
-Connecticut,Litchfield,3602,Litchfield,"180,333"
-Connecticut,Middlesex,3145,Middlesex,"162,436"
-Connecticut,New Haven,25248,NewHaven,"854,757"
-Connecticut,New London,5352,NewLondon,"265,206"
-Connecticut,Tolland,2665,Tolland,"150,721"
-Connecticut,Windham,2161,Windham,"116,782"
-Delaware,Kent,4324,Kent,"180,786"
-Delaware,New Castle,16900,NewCastle,"558,753"
-Delaware,Sussex,9493,Sussex,"234,225"
-District of Columbia,District of Columbia,19808,DistrictofColumbiaDistrictofColumbia,"705,749"
-Florida,Alachua,12176,Alachua,"269,043"
-Florida,Baker,1949,Baker,"29,210"
-Florida,Bay,8013,Bay,"174,705"
-Florida,Bradford,1355,Bradford,"28,201"
-Florida,Brevard,14301,Brevard,"601,942"
-Florida,Broward,99320,Broward,"1,952,778"
-Florida,Calhoun,825,Calhoun,"14,105"
-Florida,Charlotte,4576,Charlotte,"188,910"
-Florida,Citrus,4218,Citrus,"149,657"
-Florida,Clay,7278,Clay,"219,252"
-Florida,Collier,16618,Collier,"384,902"
-Florida,Columbia,4585,Columbia,"71,686"
-Florida,DeSoto,2163,DeSoto,"38,001"
-Florida,Dixie,947,Dixie,"16,826"
-Florida,Duval,39998,Duval,"957,755"
-Florida,Escambia,15732,Escambia,"318,316"
-Florida,Flagler,2511,Flagler,"115,081"
-Florida,Franklin,816,Franklin,"12,125"
-Florida,Gadsden,3198,Gadsden,"45,660"
-Florida,Gilchrist,713,Gilchrist,"18,582"
-Florida,Glades,649,Glades,"13,811"
-Florida,Gulf,1034,Gulf,"13,639"
-Florida,Hamilton,955,Hamilton,"14,428"
-Florida,Hardee,1720,Hardee,"26,937"
-Florida,Hendry,2413,Hendry,"42,022"
-Florida,Hernando,4507,Hernando,"193,920"
-Florida,Highlands,3447,Highlands,"106,221"
-Florida,Hillsborough,54792,Hillsborough,"1,471,968"
-Florida,Holmes,1084,Holmes,"19,617"
-Florida,Indian River,4668,IndianRiver,"159,923"
-Florida,Jackson,3661,Jackson,"46,414"
-Florida,Jefferson,730,Jefferson,"14,246"
-Florida,Lafayette,1295,Lafayette,"8,422"
-Florida,Lake,9946,Lake,"367,118"
-Florida,Lee,27585,Lee,"770,577"
-Florida,Leon,14066,Leon,"293,582"
-Florida,Levy,1319,Levy,"41,503"
-Florida,Liberty,560,Liberty,"8,354"
-Florida,Madison,1210,Madison,"18,493"
-Florida,Manatee,15511,Manatee,"403,253"
-Florida,Marion,12220,Marion,"365,579"
-Florida,Martin,5898,Martin,"161,000"
-Florida,Miami-Dade,211257,MiamiDade,"2,716,940"
-Florida,Monroe,3064,Monroe,"74,228"
-Florida,Nassau,2865,Nassau,"88,625"
-Florida,Okaloosa,8112,Okaloosa,"210,738"
-Florida,Okeechobee,1942,Okeechobee,"42,168"
-Florida,Orange,53941,Orange,"1,393,452"
-Florida,Osceola,16891,Osceola,"375,751"
-Florida,Palm Beach,60729,PalmBeach,"1,496,770"
-Florida,Pasco,13373,Pasco,"553,947"
-Florida,Pinellas,30286,Pinellas,"974,996"
-Florida,Polk,26091,Polk,"724,777"
-Florida,Putnam,2607,Putnam,"74,521"
-Florida,Santa Rosa,6903,StJohns,"264,672"
-Florida,Sarasota,12121,StLucie,"328,297"
-Florida,Seminole,11993,SantaRosa,"184,313"
-Florida,St. Johns,7881,Sarasota,"433,742"
-Florida,St. Lucie,10148,Seminole,"471,826"
-Florida,Sumter,3248,Sumter,"132,420"
-Florida,Suwannee,3192,Suwannee,"44,417"
-Florida,Taylor,1599,Taylor,"21,569"
-Florida,Union,1205,Union,"15,237"
-Florida,Volusia,14811,Volusia,"553,284"
-Florida,Wakulla,1537,Wakulla,"33,739"
-Florida,Walton,3411,Walton,"74,071"
-Florida,Washington,1440,Washington,"25,473"
-Georgia,Appling,1315,Appling,"18,386"
-Georgia,Atkinson,575,Atkinson,"8,165"
-Georgia,Bacon,744,Bacon,"11,164"
-Georgia,Baker,121,Baker,"3,038"
-Georgia,Baldwin,2590,Baldwin,"44,890"
-Georgia,Banks,705,Banks,"19,234"
-Georgia,Barrow,3212,Barrow,"83,240"
-Georgia,Bartow,4762,Bartow,"107,738"
-Georgia,Ben Hill,982,BenHill,"16,700"
-Georgia,Berrien,661,Berrien,"19,397"
-Georgia,Bibb,7361,Bibb,"153,159"
-Georgia,Bleckley,696,Bleckley,"12,873"
-Georgia,Brantley,748,Brantley,"19,109"
-Georgia,Brooks,632,Brooks,"15,457"
-Georgia,Bryan,1446,Bryan,"39,627"
-Georgia,Bulloch,3674,Bulloch,"79,608"
-Georgia,Burke,1195,Burke,"22,383"
-Georgia,Butts,995,Butts,"24,936"
-Georgia,Calhoun,292,Calhoun,"6,189"
-Georgia,Camden,1711,Camden,"54,666"
-Georgia,Candler,603,Candler,"10,803"
-Georgia,Carroll,5158,Carroll,"119,992"
-Georgia,Catoosa,1894,Catoosa,"67,580"
-Georgia,Charlton,777,Charlton,"13,392"
-Georgia,Chatham,10475,Chatham,"289,430"
-Georgia,Chattahoochee,1942,Chattahoochee,"10,907"
-Georgia,Chattooga,1182,Chattooga,"24,789"
-Georgia,Cherokee,9602,Cherokee,"258,773"
-Georgia,Clarke,7602,Clarke,"128,331"
-Georgia,Clay,148,Clay,"2,834"
-Georgia,Clayton,9956,Clayton,"292,256"
-Georgia,Clinch,531,Clinch,"6,618"
-Georgia,Cobb,27899,Cobb,"760,141"
-Georgia,Coffee,2802,Coffee,"43,273"
-Georgia,Colquitt,2584,Colquitt,"45,600"
-Georgia,Columbia,6079,Columbia,"156,714"
-Georgia,Cook,828,Cook,"17,270"
-Georgia,Coweta,4745,Coweta,"148,509"
-Georgia,Crawford,240,Crawford,"12,404"
-Georgia,Crisp,903,Crisp,"22,372"
-Georgia,Dade,480,Dade,"16,116"
-Georgia,Dawson,1075,Dawson,"26,108"
-Georgia,DeKalb,25917,Decatur,"26,404"
-Georgia,Decatur,1551,DeKalb,"759,297"
-Georgia,Dodge,1052,Dodge,"20,605"
-Georgia,Dooly,468,Dooly,"13,390"
-Georgia,Dougherty,3637,Dougherty,"87,956"
-Georgia,Douglas,5253,Douglas,"146,343"
-Georgia,Early,652,Early,"10,190"
-Georgia,Echols,270,Echols,"4,006"
-Georgia,Effingham,2120,Effingham,"64,296"
-Georgia,Elbert,1098,Elbert,"19,194"
-Georgia,Emanuel,1407,Emanuel,"22,646"
-Georgia,Evans,540,Evans,"10,654"
-Georgia,Fannin,970,Fannin,"26,188"
-Georgia,Fayette,2911,Fayette,"114,421"
-Georgia,Floyd,5204,Floyd,"98,498"
-Georgia,Forsyth,6238,Forsyth,"244,252"
-Georgia,Franklin,1159,Franklin,"23,349"
-Georgia,Fulton,37930,Fulton,"1,063,937"
-Georgia,Gilmer,1218,Gilmer,"31,369"
-Georgia,Glascock,80,Glascock,"2,971"
-Georgia,Glynn,4153,Glynn,"85,292"
-Georgia,Gordon,3243,Gordon,"57,963"
-Georgia,Grady,970,Grady,"24,633"
-Georgia,Greene,699,Greene,"18,324"
-Georgia,Gwinnett,37236,Gwinnett,"936,250"
-Georgia,Habersham,2162,Habersham,"45,328"
-Georgia,Hall,12035,Hall,"204,441"
-Georgia,Hancock,466,Hancock,"8,457"
-Georgia,Haralson,1219,Haralson,"29,792"
-Georgia,Harris,992,Harris,"35,236"
-Georgia,Hart,759,Hart,"26,205"
-Georgia,Heard,347,Heard,"11,923"
-Georgia,Henry,8064,Henry,"234,561"
-Georgia,Houston,4544,Houston,"157,863"
-Georgia,Irwin,422,Irwin,"9,416"
-Georgia,Jackson,3119,Jackson,"72,977"
-Georgia,Jasper,435,Jasper,"14,219"
-Georgia,Jeff Davis,943,JeffDavis,"15,115"
-Georgia,Jefferson,975,Jefferson,"15,362"
-Georgia,Jenkins,494,Jenkins,"8,676"
-Georgia,Johnson,521,Johnson,"9,643"
-Georgia,Jones,758,Jones,"28,735"
-Georgia,Lamar,632,Lamar,"19,077"
-Georgia,Lanier,387,Lanier,"10,423"
-Georgia,Laurens,2514,Laurens,"47,546"
-Georgia,Lee,907,Lee,"29,992"
-Georgia,Liberty,1491,Liberty,"61,435"
-Georgia,Lincoln,301,Lincoln,"7,921"
-Georgia,Long,319,Long,"19,559"
-Georgia,Lowndes,5989,Lowndes,"117,406"
-Georgia,Lumpkin,1229,Lumpkin,"33,610"
-Georgia,Macon,321,McDuffie,"21,312"
-Georgia,Madison,1047,McIntosh,"14,378"
-Georgia,Marion,239,Macon,"12,947"
-Georgia,McDuffie,909,Madison,"29,880"
-Georgia,McIntosh,365,Marion,"8,359"
-Georgia,Meriwether,754,Meriwether,"21,167"
-Georgia,Miller,401,Miller,"5,718"
-Georgia,Mitchell,947,Mitchell,"21,863"
-Georgia,Monroe,994,Monroe,"27,578"
-Georgia,Montgomery,417,Montgomery,"9,172"
-Georgia,Morgan,786,Morgan,"19,276"
-Georgia,Murray,1569,Murray,"40,096"
-Georgia,Muscogee,7075,Muscogee,"195,769"
-Georgia,Newton,3617,Newton,"111,744"
-Georgia,Oconee,1296,Oconee,"40,280"
-Georgia,Oglethorpe,523,Oglethorpe,"15,259"
-Georgia,Paulding,4545,Paulding,"168,667"
-Georgia,Peach,1004,Peach,"27,546"
-Georgia,Pickens,1048,Pickens,"32,591"
-Georgia,Pierce,1186,Pierce,"19,465"
-Georgia,Pike,746,Pike,"18,962"
-Georgia,Polk,2247,Polk,"42,613"
-Georgia,Pulaski,435,Pulaski,"11,137"
-Georgia,Putnam,957,Putnam,"22,119"
-Georgia,Quitman,77,Quitman,"2,299"
-Georgia,Rabun,532,Rabun,"17,137"
-Georgia,Randolph,364,Randolph,"6,778"
-Georgia,Richmond,9737,Richmond,"202,518"
-Georgia,Rockdale,2572,Rockdale,"90,896"
-Georgia,Schley,156,Schley,"5,257"
-Georgia,Screven,495,Screven,"13,966"
-Georgia,Seminole,506,Seminole,"8,090"
-Georgia,Spalding,2203,Spalding,"66,703"
-Georgia,Stephens,1430,Stephens,"25,925"
-Georgia,Stewart,619,Stewart,"6,621"
-Georgia,Sumter,1193,Sumter,"29,524"
-Georgia,Talbot,224,Talbot,"6,195"
-Georgia,Taliaferro,37,Taliaferro,"1,537"
-Georgia,Tattnall,1058,Tattnall,"25,286"
-Georgia,Taylor,332,Taylor,"8,020"
-Georgia,Telfair,644,Telfair,"15,860"
-Georgia,Terrell,391,Terrell,"8,531"
-Georgia,Thomas,1864,Thomas,"44,451"
-Georgia,Tift,2356,Tift,"40,644"
-Georgia,Toombs,1662,Toombs,"26,830"
-Georgia,Towns,543,Towns,"12,037"
-Georgia,Treutlen,380,Treutlen,"6,901"
-Georgia,Troup,3797,Troup,"69,922"
-Georgia,Turner,425,Turner,"7,985"
-Georgia,Twiggs,249,Twiggs,"8,120"
-Georgia,Union,1035,Union,"24,511"
-Georgia,Upson,1454,Upson,"26,320"
-Georgia,Walker,2452,Walker,"69,761"
-Georgia,Walton,3031,Walton,"94,593"
-Georgia,Ware,2554,Ware,"35,734"
-Georgia,Warren,211,Warren,"5,254"
-Georgia,Washington,1049,Washington,"20,374"
-Georgia,Wayne,1541,Wayne,"29,927"
-Georgia,Webster,62,Webster,"2,607"
-Georgia,Wheeler,419,Wheeler,"7,855"
-Georgia,White,1207,White,"30,798"
-Georgia,Whitfield,7160,Whitfield,"104,628"
-Georgia,Wilcox,352,Wilcox,"8,635"
-Georgia,Wilkes,419,Wilkes,"9,777"
-Georgia,Wilkinson,423,Wilkinson,"8,954"
-Georgia,Worth,702,Worth,"20,247"
-Hawaii,Hawaii,1523,Hawaii,"201,513"
-Hawaii,Honolulu,14676,Honolulu,"974,563"
-Hawaii,Kalawao,0,Kalawao,86
-Hawaii,Kauai,88,Kauai,"72,293"
-Hawaii,Maui,742,Maui,"167,417"
-Idaho,Ada,23065,Ada,"481,587"
-Idaho,Adams,88,Adams,"4,294"
-Idaho,Bannock,3792,Bannock,"87,808"
-Idaho,Bear Lake,157,BearLake,"6,125"
-Idaho,Benewah,234,Benewah,"9,298"
-Idaho,Bingham,2391,Bingham,"46,811"
-Idaho,Blaine,1181,Blaine,"23,021"
-Idaho,Boise,122,Boise,"7,831"
-Idaho,Bonner,839,Bonner,"45,739"
-Idaho,Bonneville,6626,Bonneville,"119,062"
-Idaho,Boundary,327,Boundary,"12,245"
-Idaho,Butte,117,Butte,"2,597"
-Idaho,Camas,51,Camas,"1,106"
-Idaho,Canyon,13482,Canyon,"229,849"
-Idaho,Caribou,409,Caribou,"7,155"
-Idaho,Cassia,1966,Cassia,"24,030"
-Idaho,Clark,48,Clark,845
-Idaho,Clearwater,362,Clearwater,"8,756"
-Idaho,Custer,131,Custer,"4,315"
-Idaho,Elmore,806,Elmore,"27,511"
-Idaho,Franklin,563,Franklin,"13,876"
-Idaho,Fremont,643,Fremont,"13,099"
-Idaho,Gem,729,Gem,"18,112"
-Idaho,Gooding,885,Gooding,"15,179"
-Idaho,Idaho,659,Idaho,"16,667"
-Idaho,Jefferson,1383,Jefferson,"29,871"
-Idaho,Jerome,1748,Jerome,"24,412"
-Idaho,Kootenai,6514,Kootenai,"165,697"
-Idaho,Latah,1565,Latah,"40,108"
-Idaho,Lemhi,411,Lemhi,"8,027"
-Idaho,Lewis,172,Lewis,"3,838"
-Idaho,Lincoln,328,Lincoln,"5,366"
-Idaho,Madison,3697,Madison,"39,907"
-Idaho,Minidoka,1616,Minidoka,"21,039"
-Idaho,Nez Perce,1990,NezPerce,"40,408"
-Idaho,Oneida,117,Oneida,"4,531"
-Idaho,Owyhee,557,Owyhee,"11,823"
-Idaho,Payette,1453,Payette,"23,951"
-Idaho,Power,432,Power,"7,681"
-Idaho,Shoshone,452,Shoshone,"12,882"
-Idaho,Teton,474,Teton,"12,142"
-Idaho,Twin Falls,6312,TwinFalls,"86,878"
-Idaho,Valley,210,Valley,"11,392"
-Idaho,Washington,659,Washington,"10,194"
-Illinois,Adams,4216,Adams,"65,435"
-Illinois,Alexander,233,Alexander,"5,761"
-Illinois,Bond,898,Bond,"16,426"
-Illinois,Boone,3425,Boone,"53,544"
-Illinois,Brown,266,Brown,"6,578"
-Illinois,Bureau,1862,Bureau,"32,628"
-Illinois,Calhoun,206,Calhoun,"4,739"
-Illinois,Carroll,959,Carroll,"14,305"
-Illinois,Cass,839,Cass,"12,147"
-Illinois,Champaign,9813,Champaign,"209,689"
-Illinois,Christian,1692,Christian,"32,304"
-Illinois,Clark,689,Clark,"15,441"
-Illinois,Clay,703,Clay,"13,184"
-Illinois,Clinton,2875,Clinton,"37,562"
-Illinois,Coles,3018,Coles,"50,621"
-Illinois,Cook,272733,Cook,"5,150,233"
-Illinois,Crawford,993,Crawford,"18,667"
-Illinois,Cumberland,538,Cumberland,"10,766"
-Illinois,De Witt,554,DeKalb,"104,897"
-Illinois,DeKalb,4415,DeWitt,"15,638"
-Illinois,Douglas,1224,Douglas,"19,465"
-Illinois,DuPage,39547,DuPage,"922,921"
-Illinois,Edgar,653,Edgar,"17,161"
-Illinois,Edwards,191,Edwards,"6,395"
-Illinois,Effingham,2324,Effingham,"34,008"
-Illinois,Fayette,1371,Fayette,"21,336"
-Illinois,Ford,631,Ford,"12,961"
-Illinois,Franklin,1798,Franklin,"38,469"
-Illinois,Fulton,1167,Fulton,"34,340"
-Illinois,Gallatin,173,Gallatin,"4,828"
-Illinois,Greene,724,Greene,"12,969"
-Illinois,Grundy,2321,Grundy,"51,054"
-Illinois,Hamilton,346,Hamilton,"8,116"
-Illinois,Hancock,849,Hancock,"17,708"
-Illinois,Hardin,111,Hardin,"3,821"
-Illinois,Henderson,243,Henderson,"6,646"
-Illinois,Henry,2177,Henry,"48,913"
-Illinois,Iroquois,1409,Iroquois,"27,114"
-Illinois,Jackson,2376,Jackson,"56,750"
-Illinois,Jasper,559,Jasper,"9,610"
-Illinois,Jefferson,1590,Jefferson,"37,684"
-Illinois,Jersey,1061,Jersey,"21,773"
-Illinois,Jo Daviess,949,JoDaviess,"21,235"
-Illinois,Johnson,636,Johnson,"12,417"
-Illinois,Kane,28225,Kane,"532,403"
-Illinois,Kankakee,7363,Kankakee,"109,862"
-Illinois,Kendall,5443,Kendall,"128,990"
-Illinois,Knox,2384,Knox,"49,699"
-Illinois,LaSalle,5331,Lake,"696,535"
-Illinois,Lake,33260,LaSalle,"108,669"
-Illinois,Lawrence,788,Lawrence,"15,678"
-Illinois,Lee,1603,Lee,"34,096"
-Illinois,Livingston,1922,Livingston,"35,648"
-Illinois,Logan,1359,Logan,"28,618"
-Illinois,Macon,5774,McDonough,"29,682"
-Illinois,Macoupin,1828,McHenry,"307,774"
-Illinois,Madison,12394,McLean,"171,517"
-Illinois,Marion,2135,Macon,"104,009"
-Illinois,Marshall,320,Macoupin,"44,926"
-Illinois,Mason,580,Madison,"262,966"
-Illinois,Massac,422,Marion,"37,205"
-Illinois,McDonough,1433,Marshall,"11,438"
-Illinois,McHenry,12483,Mason,"13,359"
-Illinois,McLean,7408,Massac,"13,772"
-Illinois,Menard,385,Menard,"12,196"
-Illinois,Mercer,638,Mercer,"15,437"
-Illinois,Monroe,1713,Monroe,"34,637"
-Illinois,Montgomery,1019,Montgomery,"28,414"
-Illinois,Morgan,1889,Morgan,"33,658"
-Illinois,Moultrie,789,Moultrie,"14,501"
-Illinois,Ogle,2468,Ogle,"50,643"
-Illinois,Peoria,7788,Peoria,"179,179"
-Illinois,Perry,882,Perry,"20,916"
-Illinois,Piatt,676,Piatt,"16,344"
-Illinois,Pike,907,Pike,"15,561"
-Illinois,Pope,66,Pope,"4,177"
-Illinois,Pulaski,353,Pulaski,"5,335"
-Illinois,Putnam,209,Putnam,"5,739"
-Illinois,Randolph,1951,Randolph,"31,782"
-Illinois,Richland,607,Richland,"15,513"
-Illinois,Rock Island,7606,RockIsland,"141,879"
-Illinois,Saline,999,StClair,"259,686"
-Illinois,Sangamon,8669,Saline,"23,491"
-Illinois,Schuyler,222,Sangamon,"194,672"
-Illinois,Scott,207,Schuyler,"6,768"
-Illinois,Shelby,1161,Scott,"4,951"
-Illinois,St. Clair,11447,Shelby,"21,634"
-Illinois,Stark,188,Stark,"5,342"
-Illinois,Stephenson,2206,Stephenson,"44,498"
-Illinois,Tazewell,5532,Tazewell,"131,803"
-Illinois,Union,1069,Union,"16,653"
-Illinois,Vermilion,3233,Vermilion,"75,758"
-Illinois,Wabash,434,Wabash,"11,520"
-Illinois,Warren,912,Warren,"16,844"
-Illinois,Washington,559,Washington,"13,887"
-Illinois,Wayne,779,Wayne,"16,215"
-Illinois,White,497,White,"13,537"
-Illinois,Whiteside,3293,Whiteside,"55,175"
-Illinois,Will,33564,Will,"690,743"
-Illinois,Williamson,3127,Williamson,"66,597"
-Illinois,Winnebago,16786,Winnebago,"282,572"
-Illinois,Woodford,1444,Woodford,"38,459"
-Indiana,Adams,1539,Adams,"35,777"
-Indiana,Allen,16218,Allen,"379,299"
-Indiana,Bartholomew,2789,Bartholomew,"83,779"
-Indiana,Benton,297,Benton,"8,748"
-Indiana,Blackford,474,Blackford,"11,758"
-Indiana,Boone,2201,Boone,"67,843"
-Indiana,Brown,302,Brown,"15,092"
-Indiana,Carroll,626,Carroll,"20,257"
-Indiana,Cass,2860,Cass,"37,689"
-Indiana,Clark,4631,Clark,"118,302"
-Indiana,Clay,997,Clay,"26,225"
-Indiana,Clinton,1635,Clinton,"32,399"
-Indiana,Crawford,257,Crawford,"10,577"
-Indiana,Daviess,1379,Daviess,"33,351"
-Indiana,DeKalb,1617,Dearborn,"49,458"
-Indiana,Dearborn,1934,Decatur,"26,559"
-Indiana,Decatur,1162,DeKalb,"43,475"
-Indiana,Delaware,4570,Delaware,"114,135"
-Indiana,Dubois,2221,Dubois,"42,736"
-Indiana,Elkhart,15714,Elkhart,"206,341"
-Indiana,Fayette,1369,Fayette,"23,102"
-Indiana,Floyd,2878,Floyd,"78,522"
-Indiana,Fountain,693,Fountain,"16,346"
-Indiana,Franklin,601,Franklin,"22,758"
-Indiana,Fulton,762,Fulton,"19,974"
-Indiana,Gibson,1623,Gibson,"33,659"
-Indiana,Grant,2357,Grant,"65,769"
-Indiana,Greene,934,Greene,"31,922"
-Indiana,Hamilton,11585,Hamilton,"338,011"
-Indiana,Hancock,2270,Hancock,"78,168"
-Indiana,Harrison,1276,Harrison,"40,515"
-Indiana,Hendricks,5409,Hendricks,"170,311"
-Indiana,Henry,2256,Henry,"47,972"
-Indiana,Howard,3017,Howard,"82,544"
-Indiana,Huntington,1067,Huntington,"36,520"
-Indiana,Jackson,1916,Jackson,"44,231"
-Indiana,Jasper,1262,Jasper,"33,562"
-Indiana,Jay,875,Jay,"20,436"
-Indiana,Jefferson,1040,Jefferson,"32,308"
-Indiana,Jennings,758,Jennings,"27,735"
-Indiana,Johnson,5678,Johnson,"158,167"
-Indiana,Knox,1617,Knox,"36,594"
-Indiana,Kosciusko,4091,Kosciusko,"79,456"
-Indiana,LaGrange,1311,LaGrange,"39,614"
-Indiana,LaPorte,4194,Lake,"485,493"
-Indiana,Lake,25026,LaPorte,"109,888"
-Indiana,Lawrence,1640,Lawrence,"45,370"
-Indiana,Madison,4405,Madison,"129,569"
-Indiana,Marion,39125,Marion,"964,582"
-Indiana,Marshall,2760,Marshall,"46,258"
-Indiana,Martin,327,Martin,"10,255"
-Indiana,Miami,1404,Miami,"35,516"
-Indiana,Monroe,4964,Monroe,"148,431"
-Indiana,Montgomery,1226,Montgomery,"38,338"
-Indiana,Morgan,1872,Morgan,"70,489"
-Indiana,Newton,512,Newton,"13,984"
-Indiana,Noble,2318,Noble,"47,744"
-Indiana,Ohio,219,Ohio,"5,875"
-Indiana,Orange,630,Orange,"19,646"
-Indiana,Owen,522,Owen,"20,799"
-Indiana,Parke,484,Parke,"16,937"
-Indiana,Perry,786,Perry,"19,169"
-Indiana,Pike,482,Pike,"12,389"
-Indiana,Porter,7390,Porter,"170,389"
-Indiana,Posey,1131,Posey,"25,427"
-Indiana,Pulaski,351,Pulaski,"12,353"
-Indiana,Putnam,1104,Putnam,"37,576"
-Indiana,Randolph,1099,Randolph,"24,665"
-Indiana,Ripley,1144,Ripley,"28,324"
-Indiana,Rush,474,Rush,"16,581"
-Indiana,Scott,919,StJoseph,"271,826"
-Indiana,Shelby,1608,Scott,"23,873"
-Indiana,Spencer,742,Shelby,"44,729"
-Indiana,St. Joseph,15539,Spencer,"20,277"
-Indiana,Starke,850,Starke,"22,995"
-Indiana,Steuben,1318,Steuben,"34,594"
-Indiana,Sullivan,791,Sullivan,"20,669"
-Indiana,Switzerland,237,Switzerland,"10,751"
-Indiana,Tippecanoe,7624,Tippecanoe,"195,732"
-Indiana,Tipton,503,Tipton,"15,148"
-Indiana,Union,248,Union,"7,054"
-Indiana,Vanderburgh,8945,Vanderburgh,"181,451"
-Indiana,Vermillion,521,Vermillion,"15,498"
-Indiana,Vigo,5419,Vigo,"107,038"
-Indiana,Wabash,1365,Wabash,"30,996"
-Indiana,Warren,216,Warren,"8,265"
-Indiana,Warrick,3002,Warrick,"62,998"
-Indiana,Washington,646,Washington,"28,036"
-Indiana,Wayne,2771,Wayne,"65,884"
-Indiana,Wells,1100,Wells,"28,296"
-Indiana,White,1095,White,"24,102"
-Indiana,Whitley,1195,Whitley,"33,964"
-Iowa,Adair,396,Adair,"7,152"
-Iowa,Adams,150,Adams,"3,602"
-Iowa,Allamakee,688,Allamakee,"13,687"
-Iowa,Appanoose,692,Appanoose,"12,426"
-Iowa,Audubon,279,Audubon,"5,496"
-Iowa,Benton,1518,Benton,"25,645"
-Iowa,Black Hawk,10005,BlackHawk,"131,228"
-Iowa,Boone,1241,Boone,"26,234"
-Iowa,Bremer,1711,Bremer,"25,062"
-Iowa,Buchanan,1047,Buchanan,"21,175"
-Iowa,Buena Vista,2865,BuenaVista,"19,620"
-Iowa,Butler,871,Butler,"14,439"
-Iowa,Calhoun,970,Calhoun,"9,668"
-Iowa,Carroll,1837,Carroll,"20,165"
-Iowa,Cass,717,Cass,"12,836"
-Iowa,Cedar,948,Cedar,"18,627"
-Iowa,Cerro Gordo,3110,CerroGordo,"42,450"
-Iowa,Cherokee,721,Cherokee,"11,235"
-Iowa,Chickasaw,747,Chickasaw,"11,933"
-Iowa,Clarke,452,Clarke,"9,395"
-Iowa,Clay,1006,Clay,"16,016"
-Iowa,Clayton,971,Clayton,"17,549"
-Iowa,Clinton,2927,Clinton,"46,429"
-Iowa,Crawford,1660,Crawford,"16,820"
-Iowa,Dallas,5792,Dallas,"93,453"
-Iowa,Davis,418,Davis,"9,000"
-Iowa,Decatur,293,Decatur,"7,870"
-Iowa,Delaware,1318,Delaware,"17,011"
-Iowa,Des Moines,2591,DesMoines,"38,967"
-Iowa,Dickinson,1232,Dickinson,"17,258"
-Iowa,Dubuque,8475,Dubuque,"97,311"
-Iowa,Emmet,688,Emmet,"9,208"
-Iowa,Fayette,927,Fayette,"19,650"
-Iowa,Floyd,895,Floyd,"15,642"
-Iowa,Franklin,662,Franklin,"10,070"
-Iowa,Fremont,334,Fremont,"6,960"
-Iowa,Greene,473,Greene,"8,888"
-Iowa,Grundy,750,Grundy,"12,232"
-Iowa,Guthrie,682,Guthrie,"10,689"
-Iowa,Hamilton,957,Hamilton,"14,773"
-Iowa,Hancock,773,Hancock,"10,630"
-Iowa,Hardin,1019,Hardin,"16,846"
-Iowa,Harrison,991,Harrison,"14,049"
-Iowa,Henry,1661,Henry,"19,954"
-Iowa,Howard,475,Howard,"9,158"
-Iowa,Humboldt,640,Humboldt,"9,558"
-Iowa,Ida,423,Ida,"6,860"
-Iowa,Iowa,842,Iowa,"16,184"
-Iowa,Jackson,1308,Jackson,"19,439"
-Iowa,Jasper,1981,Jasper,"37,185"
-Iowa,Jefferson,590,Jefferson,"18,295"
-Iowa,Johnson,8818,Johnson,"151,140"
-Iowa,Jones,2164,Jones,"20,681"
-Iowa,Keokuk,507,Keokuk,"10,246"
-Iowa,Kossuth,896,Kossuth,"14,813"
-Iowa,Lee,1826,Lee,"33,657"
-Iowa,Linn,12843,Linn,"226,706"
-Iowa,Louisa,775,Louisa,"11,035"
-Iowa,Lucas,297,Lucas,"8,600"
-Iowa,Lyon,920,Lyon,"11,755"
-Iowa,Madison,622,Madison,"16,338"
-Iowa,Mahaska,1159,Mahaska,"22,095"
-Iowa,Marion,1860,Marion,"33,253"
-Iowa,Marshall,3211,Marshall,"39,369"
-Iowa,Mills,943,Mills,"15,109"
-Iowa,Mitchell,684,Mitchell,"10,586"
-Iowa,Monona,366,Monona,"8,615"
-Iowa,Monroe,404,Monroe,"7,707"
-Iowa,Montgomery,403,Montgomery,"9,917"
-Iowa,Muscatine,2575,Muscatine,"42,664"
-Iowa,O'Brien,1163,OBrien,"13,753"
-Iowa,Osceola,480,Osceola,"5,958"
-Iowa,Page,1055,Page,"15,107"
-Iowa,Palo Alto,585,PaloAlto,"8,886"
-Iowa,Plymouth,2544,Plymouth,"25,177"
-Iowa,Pocahontas,495,Pocahontas,"6,619"
-Iowa,Polk,30369,Polk,"490,161"
-Iowa,Pottawattamie,5544,Pottawattamie,"93,206"
-Iowa,Poweshiek,886,Poweshiek,"18,504"
-Iowa,Ringgold,172,Ringgold,"4,894"
-Iowa,Sac,752,Sac,"9,721"
-Iowa,Scott,9830,Scott,"172,943"
-Iowa,Shelby,705,Shelby,"11,454"
-Iowa,Sioux,3433,Sioux,"34,855"
-Iowa,Story,6170,Story,"97,117"
-Iowa,Tama,1432,Tama,"16,854"
-Iowa,Taylor,404,Taylor,"6,121"
-Iowa,Union,656,Union,"12,241"
-Iowa,Van Buren,322,VanBuren,"7,044"
-Iowa,Wapello,2327,Wapello,"34,969"
-Iowa,Warren,2453,Warren,"51,466"
-Iowa,Washington,1234,Washington,"21,965"
-Iowa,Wayne,279,Wayne,"6,441"
-Iowa,Webster,3245,Webster,"35,904"
-Iowa,Winnebago,855,Winnebago,"10,354"
-Iowa,Winneshiek,860,Winneshiek,"19,991"
-Iowa,Woodbury,9706,Woodbury,"103,107"
-Iowa,Worth,318,Worth,"7,381"
-Iowa,Wright,1118,Wright,"12,562"
-Kansas,Allen,298,Allen,"12,369"
-Kansas,Anderson,343,Anderson,"7,858"
-Kansas,Atchison,777,Atchison,"16,073"
-Kansas,Barber,171,Barber,"4,427"
-Kansas,Barton,1455,Barton,"25,779"
-Kansas,Bourbon,463,Bourbon,"14,534"
-Kansas,Brown,606,Brown,"9,564"
-Kansas,Butler,2790,Butler,"66,911"
-Kansas,Chase,145,Chase,"2,648"
-Kansas,Chautauqua,63,Chautauqua,"3,250"
-Kansas,Cherokee,1023,Cherokee,"19,939"
-Kansas,Cheyenne,199,Cheyenne,"2,657"
-Kansas,Clark,100,Clark,"1,994"
-Kansas,Clay,410,Clay,"8,002"
-Kansas,Cloud,498,Cloud,"8,786"
-Kansas,Coffey,273,Coffey,"8,179"
-Kansas,Comanche,44,Comanche,"1,700"
-Kansas,Cowley,1267,Cowley,"34,908"
-Kansas,Crawford,2103,Crawford,"38,818"
-Kansas,Decatur,189,Decatur,"2,827"
-Kansas,Dickinson,645,Dickinson,"18,466"
-Kansas,Doniphan,391,Doniphan,"7,600"
-Kansas,Douglas,4226,Douglas,"122,259"
-Kansas,Edwards,156,Edwards,"2,798"
-Kansas,Elk,42,Elk,"2,530"
-Kansas,Ellis,2129,Ellis,"28,553"
-Kansas,Ellsworth,539,Ellsworth,"6,102"
-Kansas,Finney,4413,Finney,"36,467"
-Kansas,Ford,4421,Ford,"33,619"
-Kansas,Franklin,947,Franklin,"25,544"
-Kansas,Geary,773,Geary,"31,670"
-Kansas,Gove,272,Gove,"2,636"
-Kansas,Graham,125,Graham,"2,482"
-Kansas,Grant,649,Grant,"7,150"
-Kansas,Gray,383,Gray,"5,988"
-Kansas,Greeley,83,Greeley,"1,232"
-Kansas,Greenwood,161,Greenwood,"5,982"
-Kansas,Hamilton,128,Hamilton,"2,539"
-Kansas,Harper,275,Harper,"5,436"
-Kansas,Harvey,1553,Harvey,"34,429"
-Kansas,Haskell,235,Haskell,"3,968"
-Kansas,Hodgeman,124,Hodgeman,"1,794"
-Kansas,Jackson,573,Jackson,"13,171"
-Kansas,Jefferson,601,Jefferson,"19,043"
-Kansas,Jewell,51,Jewell,"2,879"
-Kansas,Johnson,23891,Johnson,"602,401"
-Kansas,Kearny,304,Kearny,"3,838"
-Kansas,Kingman,302,Kingman,"7,152"
-Kansas,Kiowa,100,Kiowa,"2,475"
-Kansas,Labette,734,Labette,"19,618"
-Kansas,Lane,67,Lane,"1,535"
-Kansas,Leavenworth,3408,Leavenworth,"81,758"
-Kansas,Lincoln,52,Lincoln,"2,962"
-Kansas,Linn,248,Linn,"9,703"
-Kansas,Logan,207,Logan,"2,794"
-Kansas,Lyon,2230,Lyon,"33,195"
-Kansas,Marion,373,McPherson,"28,542"
-Kansas,Marshall,362,Marion,"11,884"
-Kansas,McPherson,1157,Marshall,"9,707"
-Kansas,Meade,280,Meade,"4,033"
-Kansas,Miami,866,Miami,"34,237"
-Kansas,Mitchell,179,Mitchell,"5,979"
-Kansas,Montgomery,969,Montgomery,"31,829"
-Kansas,Morris,145,Morris,"5,620"
-Kansas,Morton,137,Morton,"2,587"
-Kansas,Nemaha,873,Nemaha,"10,231"
-Kansas,Neosho,592,Neosho,"16,007"
-Kansas,Ness,231,Ness,"2,750"
-Kansas,Norton,1040,Norton,"5,361"
-Kansas,Osage,425,Osage,"15,949"
-Kansas,Osborne,66,Osborne,"3,421"
-Kansas,Ottawa,192,Ottawa,"5,704"
-Kansas,Pawnee,591,Pawnee,"6,414"
-Kansas,Phillips,356,Phillips,"5,234"
-Kansas,Pottawatomie,613,Pottawatomie,"24,383"
-Kansas,Pratt,437,Pratt,"9,164"
-Kansas,Rawlins,160,Rawlins,"2,530"
-Kansas,Reno,4125,Reno,"61,998"
-Kansas,Republic,244,Republic,"4,636"
-Kansas,Rice,333,Rice,"9,537"
-Kansas,Riley,3157,Riley,"74,232"
-Kansas,Rooks,284,Rooks,"4,920"
-Kansas,Rush,181,Rush,"3,036"
-Kansas,Russell,460,Russell,"6,856"
-Kansas,Saline,2002,Saline,"54,224"
-Kansas,Scott,318,Scott,"4,823"
-Kansas,Sedgwick,23476,Sedgwick,"516,042"
-Kansas,Seward,2628,Seward,"21,428"
-Kansas,Shawnee,6381,Shawnee,"176,875"
-Kansas,Sheridan,288,Sheridan,"2,521"
-Kansas,Sherman,394,Sherman,"5,917"
-Kansas,Smith,108,Smith,"3,583"
-Kansas,Stafford,177,Stafford,"4,156"
-Kansas,Stanton,132,Stanton,"2,006"
-Kansas,Stevens,395,Stevens,"5,485"
-Kansas,Sumner,658,Sumner,"22,836"
-Kansas,Thomas,597,Thomas,"7,777"
-Kansas,Trego,192,Trego,"2,803"
-Kansas,Wabaunsee,278,Wabaunsee,"6,931"
-Kansas,Wallace,133,Wallace,"1,518"
-Kansas,Washington,264,Washington,"5,406"
-Kansas,Wichita,124,Wichita,"2,119"
-Kansas,Wilson,242,Wilson,"8,525"
-Kansas,Woodson,56,Woodson,"3,138"
-Kansas,Wyandotte,10535,Wyandotte,"165,429"
-Kentucky,Adair,673,Adair,"19,202"
-Kentucky,Allen,658,Allen,"21,315"
-Kentucky,Anderson,435,Anderson,"22,747"
-Kentucky,Ballard,122,Ballard,"7,888"
-Kentucky,Barren,1788,Barren,"44,249"
-Kentucky,Bath,219,Bath,"12,500"
-Kentucky,Bell,1138,Bell,"26,032"
-Kentucky,Boone,3780,Boone,"133,581"
-Kentucky,Bourbon,480,Bourbon,"19,788"
-Kentucky,Boyd,1299,Boyd,"46,718"
-Kentucky,Boyle,773,Boyle,"30,060"
-Kentucky,Bracken,117,Bracken,"8,303"
-Kentucky,Breathitt,284,Breathitt,"12,630"
-Kentucky,Breckinridge,404,Breckinridge,"20,477"
-Kentucky,Bullitt,2458,Bullitt,"81,676"
-Kentucky,Butler,494,Butler,"12,879"
-Kentucky,Caldwell,478,Caldwell,"12,747"
-Kentucky,Calloway,1479,Calloway,"39,001"
-Kentucky,Campbell,2386,Campbell,"93,584"
-Kentucky,Carlisle,170,Carlisle,"4,760"
-Kentucky,Carroll,293,Carroll,"10,631"
-Kentucky,Carter,584,Carter,"26,797"
-Kentucky,Casey,453,Casey,"16,159"
-Kentucky,Christian,2626,Christian,"70,461"
-Kentucky,Clark,763,Clark,"36,263"
-Kentucky,Clay,906,Clay,"19,901"
-Kentucky,Clinton,348,Clinton,"10,218"
-Kentucky,Crittenden,215,Crittenden,"8,806"
-Kentucky,Cumberland,202,Cumberland,"6,614"
-Kentucky,Daviess,2993,Daviess,"101,511"
-Kentucky,Edmonson,315,Edmonson,"12,150"
-Kentucky,Elliott,551,Elliott,"7,517"
-Kentucky,Estill,399,Estill,"14,106"
-Kentucky,Fayette,14967,Fayette,"323,152"
-Kentucky,Fleming,277,Fleming,"14,581"
-Kentucky,Floyd,991,Floyd,"35,589"
-Kentucky,Franklin,1220,Franklin,"50,991"
-Kentucky,Fulton,271,Fulton,"5,969"
-Kentucky,Gallatin,178,Gallatin,"8,869"
-Kentucky,Garrard,485,Garrard,"17,666"
-Kentucky,Grant,525,Grant,"25,069"
-Kentucky,Graves,1504,Graves,"37,266"
-Kentucky,Grayson,810,Grayson,"26,427"
-Kentucky,Green,435,Green,"10,941"
-Kentucky,Greenup,1058,Greenup,"35,098"
-Kentucky,Hancock,270,Hancock,"8,722"
-Kentucky,Hardin,3594,Hardin,"110,958"
-Kentucky,Harlan,791,Harlan,"26,010"
-Kentucky,Harrison,397,Harrison,"18,886"
-Kentucky,Hart,669,Hart,"19,035"
-Kentucky,Henderson,1829,Henderson,"45,210"
-Kentucky,Henry,437,Henry,"16,126"
-Kentucky,Hickman,138,Hickman,"4,380"
-Kentucky,Hopkins,1600,Hopkins,"44,686"
-Kentucky,Jackson,611,Jackson,"13,329"
-Kentucky,Jefferson,32073,Jefferson,"766,757"
-Kentucky,Jessamine,1506,Jessamine,"54,115"
-Kentucky,Johnson,642,Johnson,"22,188"
-Kentucky,Kenton,4542,Kenton,"166,998"
-Kentucky,Knott,498,Knott,"14,806"
-Kentucky,Knox,1106,Knox,"31,145"
-Kentucky,Larue,487,Larue,"14,398"
-Kentucky,Laurel,2206,Laurel,"60,813"
-Kentucky,Lawrence,331,Lawrence,"15,317"
-Kentucky,Lee,771,Lee,"7,403"
-Kentucky,Leslie,190,Leslie,"9,877"
-Kentucky,Letcher,443,Letcher,"21,553"
-Kentucky,Lewis,438,Lewis,"13,275"
-Kentucky,Lincoln,542,Lincoln,"24,549"
-Kentucky,Livingston,238,Livingston,"9,194"
-Kentucky,Logan,1081,Logan,"27,102"
-Kentucky,Lyon,171,Lyon,"8,210"
-Kentucky,Madison,3281,McCracken,"65,418"
-Kentucky,Magoffin,353,McCreary,"17,231"
-Kentucky,Marion,827,McLean,"9,207"
-Kentucky,Marshall,811,Madison,"92,987"
-Kentucky,Martin,358,Magoffin,"12,161"
-Kentucky,Mason,321,Marion,"19,273"
-Kentucky,McCracken,2173,Marshall,"31,100"
-Kentucky,McCreary,331,Martin,"11,195"
-Kentucky,McLean,343,Mason,"17,070"
-Kentucky,Meade,596,Meade,"28,572"
-Kentucky,Menifee,112,Menifee,"6,489"
-Kentucky,Mercer,578,Mercer,"21,933"
-Kentucky,Metcalfe,338,Metcalfe,"10,071"
-Kentucky,Monroe,644,Monroe,"10,650"
-Kentucky,Montgomery,789,Montgomery,"28,157"
-Kentucky,Morgan,256,Morgan,"13,309"
-Kentucky,Muhlenberg,1244,Muhlenberg,"30,622"
-Kentucky,Nelson,1840,Nelson,"46,233"
-Kentucky,Nicholas,151,Nicholas,"7,269"
-Kentucky,Ohio,824,Ohio,"23,994"
-Kentucky,Oldham,1964,Oldham,"66,799"
-Kentucky,Owen,168,Owen,"10,901"
-Kentucky,Owsley,170,Owsley,"4,415"
-Kentucky,Pendleton,273,Pendleton,"14,590"
-Kentucky,Perry,839,Perry,"25,758"
-Kentucky,Pike,1590,Pike,"57,876"
-Kentucky,Powell,392,Powell,"12,359"
-Kentucky,Pulaski,1371,Pulaski,"64,979"
-Kentucky,Robertson,66,Robertson,"2,108"
-Kentucky,Rockcastle,457,Rockcastle,"16,695"
-Kentucky,Rowan,648,Rowan,"24,460"
-Kentucky,Russell,512,Russell,"17,923"
-Kentucky,Scott,1525,Scott,"57,004"
-Kentucky,Shelby,1989,Shelby,"49,024"
-Kentucky,Simpson,524,Simpson,"18,572"
-Kentucky,Spencer,538,Spencer,"19,351"
-Kentucky,Taylor,794,Taylor,"25,769"
-Kentucky,Todd,372,Todd,"12,294"
-Kentucky,Trigg,351,Trigg,"14,651"
-Kentucky,Trimble,142,Trimble,"8,471"
-Kentucky,Union,668,Union,"14,381"
-Kentucky,Warren,6586,Warren,"132,896"
-Kentucky,Washington,435,Washington,"12,095"
-Kentucky,Wayne,446,Wayne,"20,333"
-Kentucky,Webster,511,Webster,"12,942"
-Kentucky,Whitley,1319,Whitley,"36,264"
-Kentucky,Wolfe,149,Wolfe,"7,157"
-Kentucky,Woodford,632,Woodford,"26,734"
-Louisiana,Acadia,3678,AcadiaParishLouisiana,"62,045"
-Louisiana,Allen,2046,AllenParishLouisiana,"25,627"
-Louisiana,Ascension,5325,AscensionParishLouisiana,"126,604"
-Louisiana,Assumption,972,AssumptionParishLouisiana,"21,891"
-Louisiana,Avoyelles,1997,AvoyellesParishLouisiana,"40,144"
-Louisiana,Beauregard,1270,BeauregardParishLouisiana,"37,497"
-Louisiana,Bienville,726,BienvilleParishLouisiana,"13,241"
-Louisiana,Bossier,5774,BossierParishLouisiana,"127,039"
-Louisiana,Caddo,12329,CaddoParishLouisiana,"240,204"
-Louisiana,Calcasieu,9924,CalcasieuParishLouisiana,"203,436"
-Louisiana,Caldwell,593,CaldwellParishLouisiana,"9,918"
-Louisiana,Cameron,272,CameronParishLouisiana,"6,973"
-Louisiana,Catahoula,582,CatahoulaParishLouisiana,"9,494"
-Louisiana,Claiborne,715,ClaiborneParishLouisiana,"15,670"
-Louisiana,Concordia,911,ConcordiaParishLouisiana,"19,259"
-Louisiana,De Soto,1178,DeSotoParishLouisiana,"27,463"
-Louisiana,East Baton Rouge,18764,EastBatonRougeParishLouisiana,"440,059"
-Louisiana,East Carroll,670,EastCarrollParishLouisiana,"6,861"
-Louisiana,East Feliciana,2048,EastFelicianaParishLouisiana,"19,135"
-Louisiana,Evangeline,1753,EvangelineParishLouisiana,"33,395"
-Louisiana,Franklin,1653,FranklinParishLouisiana,"20,015"
-Louisiana,Grant,664,GrantParishLouisiana,"22,389"
-Louisiana,Iberia,3446,IberiaParishLouisiana,"69,830"
-Louisiana,Iberville,1799,IbervilleParishLouisiana,"32,511"
-Louisiana,Jackson,1098,JacksonParishLouisiana,"15,744"
-Louisiana,Jefferson,20927,JeffersonParishLouisiana,"432,493"
-Louisiana,Jefferson Davis,1603,JeffersonDavisParishLouisiana,"31,368"
-Louisiana,LaSalle,819,LafayetteParishLouisiana,"244,390"
-Louisiana,Lafayette,11146,LafourcheParishLouisiana,"97,614"
-Louisiana,Lafourche,4455,LaSalleParishLouisiana,"14,892"
-Louisiana,Lincoln,2318,LincolnParishLouisiana,"46,742"
-Louisiana,Livingston,5456,LivingstonParishLouisiana,"140,789"
-Louisiana,Madison,1018,MadisonParishLouisiana,"10,951"
-Louisiana,Morehouse,1197,MorehouseParishLouisiana,"24,874"
-Louisiana,Natchitoches,1909,NatchitochesParishLouisiana,"38,158"
-Louisiana,Orleans,14978,OrleansParishLouisiana,"390,144"
-Louisiana,Ouachita,9267,OuachitaParishLouisiana,"153,279"
-Louisiana,Plaquemines,1057,PlaqueminesParishLouisiana,"23,197"
-Louisiana,Pointe Coupee,1302,PointeCoupeeParishLouisiana,"21,730"
-Louisiana,Rapides,5948,RapidesParishLouisiana,"129,648"
-Louisiana,Red River,551,RedRiverParishLouisiana,"8,442"
-Louisiana,Richland,1323,RichlandParishLouisiana,"20,122"
-Louisiana,Sabine,1320,SabineParishLouisiana,"23,884"
-Louisiana,St. Bernard,1715,StBernardParishLouisiana,"47,244"
-Louisiana,St. Charles,2391,StCharlesParishLouisiana,"53,100"
-Louisiana,St. Helena,501,StHelenaParishLouisiana,"10,132"
-Louisiana,St. James,934,StJamesParishLouisiana,"21,096"
-Louisiana,St. John the Baptist,1873,StJohntheBaptistParishLouisiana,"42,837"
-Louisiana,St. Landry,4597,StLandryParishLouisiana,"82,124"
-Louisiana,St. Martin,2545,StMartinParishLouisiana,"53,431"
-Louisiana,St. Mary,2271,StMaryParishLouisiana,"49,348"
-Louisiana,St. Tammany,9514,StTammanyParishLouisiana,"260,419"
-Louisiana,Tangipahoa,6190,TangipahoaParishLouisiana,"134,758"
-Louisiana,Tensas,205,TensasParishLouisiana,"4,334"
-Louisiana,Terrebonne,4303,TerrebonneParishLouisiana,"110,461"
-Louisiana,Union,1338,UnionParishLouisiana,"22,108"
-Louisiana,Vermilion,2404,VermilionParishLouisiana,"59,511"
-Louisiana,Vernon,1327,VernonParishLouisiana,"47,429"
-Louisiana,Washington,2150,WashingtonParishLouisiana,"46,194"
-Louisiana,Webster,1844,WebsterParishLouisiana,"38,340"
-Louisiana,West Baton Rouge,1228,WestBatonRougeParishLouisiana,"26,465"
-Louisiana,West Carroll,556,WestCarrollParishLouisiana,"10,830"
-Louisiana,West Feliciana,779,WestFelicianaParishLouisiana,"15,568"
-Louisiana,Winn,906,WinnParishLouisiana,"13,904"
-Maine,Androscoggin,1309,Androscoggin,"108,277"
-Maine,Aroostook,91,Aroostook,"67,055"
-Maine,Cumberland,3458,Cumberland,"295,003"
-Maine,Franklin,187,Franklin,"30,199"
-Maine,Hancock,201,Hancock,"54,987"
-Maine,Kennebec,639,Kennebec,"122,302"
-Maine,Knox,179,Knox,"39,772"
-Maine,Lincoln,131,Lincoln,"34,634"
-Maine,Oxford,277,Oxford,"57,975"
-Maine,Penobscot,598,Penobscot,"152,148"
-Maine,Piscataquis,32,Piscataquis,"16,785"
-Maine,Sagadahoc,127,Sagadahoc,"35,856"
-Maine,Somerset,387,Somerset,"50,484"
-Maine,Waldo,202,Waldo,"39,715"
-Maine,Washington,172,Washington,"31,379"
-Maine,York,1965,York,"207,641"
-Maryland,Allegany,2115,Allegany,"70,416"
-Maryland,Anne Arundel,15103,AnneArundel,"579,234"
-Maryland,Baltimore,26088,Baltimore,"827,370"
-Maryland,Baltimore City,22010,BaltimorecityMaryland,"593,490"
-Maryland,Calvert,1439,Calvert,"92,525"
-Maryland,Caroline,844,Caroline,"33,406"
-Maryland,Carroll,2930,Carroll,"168,447"
-Maryland,Cecil,1795,Cecil,"102,855"
-Maryland,Charles,3938,Charles,"163,257"
-Maryland,Dorchester,932,Dorchester,"31,929"
-Maryland,Frederick,5943,Frederick,"259,547"
-Maryland,Garrett,447,Garrett,"29,014"
-Maryland,Harford,5184,Harford,"255,441"
-Maryland,Howard,7201,Howard,"325,690"
-Maryland,Kent,391,Kent,"19,422"
-Maryland,Montgomery,30580,Montgomery,"1,050,688"
-Maryland,Prince George's,38053,PrinceGeorges,"909,327"
-Maryland,Queen Anne's,990,QueenAnnes,"50,381"
-Maryland,Somerset,636,StMarys,"113,510"
-Maryland,St. Mary's,1851,Somerset,"25,616"
-Maryland,Talbot,733,Talbot,"37,181"
-Maryland,Washington,3409,Washington,"151,049"
-Maryland,Wicomico,3071,Wicomico,"103,609"
-Maryland,Worcester,1403,Worcester,"52,276"
-Massachusetts,Barnstable,2488,Barnstable,"212,990"
-Massachusetts,Berkshire,1201,Berkshire,"124,944"
-Massachusetts,Bristol,17337,Bristol,"565,217"
-Massachusetts,Dukes and Nantucket,486,Dukes,"28,731"
-Massachusetts,Essex,30674,Essex,"789,034"
-Massachusetts,Franklin,571,Franklin,"70,180"
-Massachusetts,Hampden,13929,Hampden,"466,372"
-Massachusetts,Hampshire,2037,Hampshire,"160,830"
-Massachusetts,Middlesex,40680,Middlesex,"1,611,699"
-Massachusetts,Norfolk,14569,Norfolk,"706,775"
-Massachusetts,Plymouth,13505,Plymouth,"521,202"
-Massachusetts,Suffolk,34270,Suffolk,"803,907"
-Massachusetts,Worcester,22038,Worcester,"830,622"
-Michigan,Alcona,124,Alcona,"10,405"
-Michigan,Alger,200,Alger,"9,108"
-Michigan,Allegan,3212,Allegan,"118,081"
-Michigan,Alpena,432,Alpena,"28,405"
-Michigan,Antrim,313,Antrim,"23,324"
-Michigan,Arenac,297,Arenac,"14,883"
-Michigan,Baraga,385,Baraga,"8,209"
-Michigan,Barry,1652,Barry,"61,550"
-Michigan,Bay,3500,Bay,"103,126"
-Michigan,Benzie,275,Benzie,"17,766"
-Michigan,Berrien,5336,Berrien,"153,401"
-Michigan,Branch,1898,Branch,"43,517"
-Michigan,Calhoun,5263,Calhoun,"134,159"
-Michigan,Cass,1865,Cass,"51,787"
-Michigan,Charlevoix,443,Charlevoix,"26,143"
-Michigan,Cheboygan,384,Cheboygan,"25,276"
-Michigan,Chippewa,637,Chippewa,"37,349"
-Michigan,Clare,610,Clare,"30,950"
-Michigan,Clinton,2341,Clinton,"79,595"
-Michigan,Crawford,275,Crawford,"14,029"
-Michigan,Delta,2261,Delta,"35,784"
-Michigan,Dickinson,1475,Dickinson,"25,239"
-Michigan,Eaton,2510,Eaton,"110,268"
-Michigan,Emmet,823,Emmet,"33,415"
-Michigan,Genesee,12199,Genesee,"405,813"
-Michigan,Gladwin,626,Gladwin,"25,449"
-Michigan,Gogebic,689,Gogebic,"13,975"
-Michigan,Grand Traverse,1517,GrandTraverse,"93,088"
-Michigan,Gratiot,1595,Gratiot,"40,711"
-Michigan,Hillsdale,1298,Hillsdale,"45,605"
-Michigan,Houghton,1411,Houghton,"35,684"
-Michigan,Huron,575,Huron,"30,981"
-Michigan,Ingham,7598,Ingham,"292,406"
-Michigan,Ionia,1843,Ionia,"64,697"
-Michigan,Iosco,582,Iosco,"25,127"
-Michigan,Iron,659,Iron,"11,066"
-Michigan,Isabella,2060,Isabella,"69,872"
-Michigan,Jackson,3992,Jackson,"158,510"
-Michigan,Kalamazoo,8175,Kalamazoo,"265,066"
-Michigan,Kalkaska,287,Kalkaska,"18,038"
-Michigan,Kent,27706,Kent,"656,955"
-Michigan,Keweenaw,60,Keweenaw,"2,116"
-Michigan,Lake,160,Lake,"11,853"
-Michigan,Lapeer,1871,Lapeer,"87,607"
-Michigan,Leelanau,305,Leelanau,"21,761"
-Michigan,Lenawee,2051,Lenawee,"98,451"
-Michigan,Livingston,4344,Livingston,"191,995"
-Michigan,Luce,153,Luce,"6,229"
-Michigan,Mackinac,239,Mackinac,"10,799"
-Michigan,Macomb,31164,Macomb,"873,972"
-Michigan,Manistee,297,Manistee,"24,558"
-Michigan,Marquette,2463,Marquette,"66,699"
-Michigan,Mason,498,Mason,"29,144"
-Michigan,Mecosta,1013,Mecosta,"43,453"
-Michigan,Menominee,1151,Menominee,"22,780"
-Michigan,Midland,2500,Midland,"83,156"
-Michigan,Missaukee,231,Missaukee,"15,118"
-Michigan,Monroe,4217,Monroe,"150,500"
-Michigan,Montcalm,1500,Montcalm,"63,888"
-Michigan,Montmorency,112,Montmorency,"9,328"
-Michigan,Muskegon,6028,Muskegon,"173,566"
-Michigan,Newaygo,1286,Newaygo,"48,980"
-Michigan,Oakland,39629,Oakland,"1,257,584"
-Michigan,Oceana,1025,Oceana,"26,467"
-Michigan,Ogemaw,383,Ogemaw,"20,997"
-Michigan,Ontonagon,254,Ontonagon,"5,720"
-Michigan,Osceola,403,Osceola,"23,460"
-Michigan,Oscoda,113,Oscoda,"8,241"
-Michigan,Otsego,620,Otsego,"24,668"
-Michigan,Ottawa,11264,Ottawa,"291,830"
-Michigan,Presque Isle,184,PresqueIsle,"12,592"
-Michigan,Roscommon,465,Roscommon,"24,019"
-Michigan,Saginaw,7198,Saginaw,"190,539"
-Michigan,Sanilac,517,StClair,"159,128"
-Michigan,Schoolcraft,163,StJoseph,"60,964"
-Michigan,Shiawassee,1573,Sanilac,"41,170"
-Michigan,St. Clair,3527,Schoolcraft,"8,094"
-Michigan,St. Joseph,2228,Shiawassee,"68,122"
-Michigan,Tuscola,1394,Tuscola,"52,245"
-Michigan,Van Buren,2274,VanBuren,"75,677"
-Michigan,Washtenaw,8492,Washtenaw,"367,601"
-Michigan,Wayne,56100,Wayne,"1,749,343"
-Michigan,Wexford,460,Wexford,"33,631"
-Minnesota,Aitkin,594,Aitkin,"15,886"
-Minnesota,Anoka,18296,Anoka,"356,921"
-Minnesota,Becker,1557,Becker,"34,423"
-Minnesota,Beltrami,1696,Beltrami,"47,188"
-Minnesota,Benton,2449,Benton,"40,889"
-Minnesota,Big Stone,260,BigStone,"4,991"
-Minnesota,Blue Earth,3525,BlueEarth,"67,653"
-Minnesota,Brown,1024,Brown,"25,008"
-Minnesota,Carlton,1350,Carlton,"35,871"
-Minnesota,Carver,3714,Carver,"105,089"
-Minnesota,Cass,1094,Cass,"29,779"
-Minnesota,Chippewa,704,Chippewa,"11,800"
-Minnesota,Chisago,2624,Chisago,"56,579"
-Minnesota,Clay,4144,Clay,"64,222"
-Minnesota,Clearwater,396,Clearwater,"8,818"
-Minnesota,Cook,54,Cook,"5,463"
-Minnesota,Cottonwood,601,Cottonwood,"11,196"
-Minnesota,Crow Wing,2908,CrowWing,"65,055"
-Minnesota,Dakota,17787,Dakota,"429,021"
-Minnesota,Dodge,741,Dodge,"20,934"
-Minnesota,Douglas,1964,Douglas,"38,141"
-Minnesota,Faribault,444,Faribault,"13,653"
-Minnesota,Fillmore,557,Fillmore,"21,067"
-Minnesota,Freeborn,1279,Freeborn,"30,281"
-Minnesota,Goodhue,1623,Goodhue,"46,340"
-Minnesota,Grant,205,Grant,"5,972"
-Minnesota,Hennepin,55721,Hennepin,"1,265,843"
-Minnesota,Houston,567,Houston,"18,600"
-Minnesota,Hubbard,867,Hubbard,"21,491"
-Minnesota,Isanti,1502,Isanti,"40,596"
-Minnesota,Itasca,1566,Itasca,"45,130"
-Minnesota,Jackson,373,Jackson,"9,846"
-Minnesota,Kanabec,475,Kanabec,"16,337"
-Minnesota,Kandiyohi,3177,Kandiyohi,"43,199"
-Minnesota,Kittson,157,Kittson,"4,298"
-Minnesota,Koochiching,308,Koochiching,"12,229"
-Minnesota,Lac qui Parle,295,LacquiParle,"6,623"
-Minnesota,Lake,304,Lake,"10,641"
-Minnesota,Lake of the Woods,78,LakeoftheWoods,"3,740"
-Minnesota,Le Sueur,1209,LeSueur,"28,887"
-Minnesota,Lincoln,286,Lincoln,"5,639"
-Minnesota,Lyon,1747,Lyon,"25,474"
-Minnesota,Mahnomen,219,Mahnomen,"5,527"
-Minnesota,Marshall,375,Marshall,"9,336"
-Minnesota,Martin,913,Martin,"19,683"
-Minnesota,McLeod,1634,McLeod,"35,893"
-Minnesota,Meeker,926,Meeker,"23,222"
-Minnesota,Mille Lacs,1201,MilleLacs,"26,277"
-Minnesota,Morrison,1934,Morrison,"33,386"
-Minnesota,Mower,2228,Mower,"40,062"
-Minnesota,Murray,496,Murray,"8,194"
-Minnesota,Nicollet,1361,Nicollet,"34,274"
-Minnesota,Nobles,2887,Nobles,"21,629"
-Minnesota,Norman,285,Norman,"6,375"
-Minnesota,Olmsted,5800,Olmsted,"158,293"
-Minnesota,Otter Tail,2328,OtterTail,"58,746"
-Minnesota,Pennington,466,Pennington,"14,119"
-Minnesota,Pine,1055,Pine,"29,579"
-Minnesota,Pipestone,612,Pipestone,"9,126"
-Minnesota,Polk,2021,Polk,"31,364"
-Minnesota,Pope,434,Pope,"11,249"
-Minnesota,Ramsey,23623,Ramsey,"550,321"
-Minnesota,Red Lake,167,RedLake,"4,055"
-Minnesota,Redwood,687,Redwood,"15,170"
-Minnesota,Renville,620,Renville,"14,548"
-Minnesota,Rice,3358,Rice,"66,972"
-Minnesota,Rock,583,Rock,"9,315"
-Minnesota,Roseau,874,Roseau,"15,165"
-Minnesota,Scott,6884,StLouis,"199,070"
-Minnesota,Sherburne,4734,Scott,"149,013"
-Minnesota,Sibley,632,Sherburne,"97,238"
-Minnesota,St. Louis,6766,Sibley,"14,865"
-Minnesota,Stearns,11593,Stearns,"161,075"
-Minnesota,Steele,1543,Steele,"36,649"
-Minnesota,Stevens,402,Stevens,"9,805"
-Minnesota,Swift,457,Swift,"9,266"
-Minnesota,Todd,1554,Todd,"24,664"
-Minnesota,Traverse,114,Traverse,"3,259"
-Minnesota,Wabasha,835,Wabasha,"21,627"
-Minnesota,Wadena,638,Wadena,"13,682"
-Minnesota,Waseca,1223,Waseca,"18,612"
-Minnesota,Washington,11756,Washington,"262,440"
-Minnesota,Watonwan,744,Watonwan,"10,897"
-Minnesota,Wilkin,299,Wilkin,"6,207"
-Minnesota,Winona,2334,Winona,"50,484"
-Minnesota,Wright,6046,Wright,"138,377"
-Minnesota,Yellow Medicine,508,YellowMedicine,"9,709"
-Mississippi,Adams,1318,Adams,"30,693"
-Mississippi,Alcorn,1410,Alcorn,"36,953"
-Mississippi,Amite,486,Amite,"12,297"
-Mississippi,Attala,1038,Attala,"18,174"
-Mississippi,Benton,480,Benton,"8,259"
-Mississippi,Bolivar,2350,Bolivar,"30,628"
-Mississippi,Calhoun,706,Calhoun,"14,361"
-Mississippi,Carroll,680,Carroll,"9,947"
-Mississippi,Chickasaw,1002,Chickasaw,"17,103"
-Mississippi,Choctaw,298,Choctaw,"8,210"
-Mississippi,Claiborne,572,Claiborne,"8,988"
-Mississippi,Clarke,866,Clarke,"15,541"
-Mississippi,Clay,843,Clay,"19,316"
-Mississippi,Coahoma,1442,Coahoma,"22,124"
-Mississippi,Copiah,1567,Copiah,"28,065"
-Mississippi,Covington,1142,Covington,"18,636"
-Mississippi,DeSoto,9358,DeSoto,"184,945"
-Mississippi,Forrest,3548,Forrest,"74,897"
-Mississippi,Franklin,308,Franklin,"7,713"
-Mississippi,George,1188,George,"24,500"
-Mississippi,Greene,573,Greene,"13,586"
-Mississippi,Grenada,1340,Grenada,"20,758"
-Mississippi,Hancock,1114,Hancock,"47,632"
-Mississippi,Harrison,6666,Harrison,"208,080"
-Mississippi,Hinds,9338,Hinds,"231,840"
-Mississippi,Holmes,1223,Holmes,"17,010"
-Mississippi,Humphreys,515,Humphreys,"8,064"
-Mississippi,Issaquena,108,Issaquena,"1,327"
-Mississippi,Itawamba,1424,Itawamba,"23,390"
-Mississippi,Jackson,5947,Jackson,"143,617"
-Mississippi,Jasper,788,Jasper,"16,383"
-Mississippi,Jefferson,332,Jefferson,"6,990"
-Mississippi,Jefferson Davis,528,JeffersonDavis,"11,128"
-Mississippi,Jones,3371,Jones,"68,098"
-Mississippi,Kemper,395,Kemper,"9,742"
-Mississippi,Lafayette,3061,Lafayette,"54,019"
-Mississippi,Lamar,2689,Lamar,"63,343"
-Mississippi,Lauderdale,3224,Lauderdale,"74,125"
-Mississippi,Lawrence,685,Lawrence,"12,586"
-Mississippi,Leake,1292,Leake,"22,786"
-Mississippi,Lee,4672,Lee,"85,436"
-Mississippi,Leflore,1977,Leflore,"28,183"
-Mississippi,Lincoln,1766,Lincoln,"34,153"
-Mississippi,Lowndes,2218,Lowndes,"58,595"
-Mississippi,Madison,4498,Madison,"106,272"
-Mississippi,Marion,1071,Marion,"24,573"
-Mississippi,Marshall,2029,Marshall,"35,294"
-Mississippi,Monroe,1857,Monroe,"35,252"
-Mississippi,Montgomery,703,Montgomery,"9,775"
-Mississippi,Neshoba,2144,Neshoba,"29,118"
-Mississippi,Newton,1016,Newton,"21,018"
-Mississippi,Noxubee,678,Noxubee,"10,417"
-Mississippi,Oktibbeha,2351,Oktibbeha,"49,587"
-Mississippi,Panola,2050,Panola,"34,192"
-Mississippi,Pearl River,1385,PearlRiver,"55,535"
-Mississippi,Perry,631,Perry,"11,973"
-Mississippi,Pike,1582,Pike,"39,288"
-Mississippi,Pontotoc,1875,Pontotoc,"32,174"
-Mississippi,Prentiss,1359,Prentiss,"25,126"
-Mississippi,Quitman,469,Quitman,"6,792"
-Mississippi,Rankin,5078,Rankin,"155,271"
-Mississippi,Scott,1452,Scott,"28,124"
-Mississippi,Sharkey,300,Sharkey,"4,321"
-Mississippi,Simpson,1394,Simpson,"26,658"
-Mississippi,Smith,672,Smith,"15,916"
-Mississippi,Stone,687,Stone,"18,336"
-Mississippi,Sunflower,1852,Sunflower,"25,110"
-Mississippi,Tallahatchie,941,Tallahatchie,"13,809"
-Mississippi,Tate,1574,Tate,"28,321"
-Mississippi,Tippah,1183,Tippah,"22,015"
-Mississippi,Tishomingo,1031,Tishomingo,"19,383"
-Mississippi,Tunica,590,Tunica,"9,632"
-Mississippi,Union,1555,Union,"28,815"
-Mississippi,Walthall,732,Walthall,"14,286"
-Mississippi,Warren,1691,Warren,"45,381"
-Mississippi,Washington,3002,Washington,"43,909"
-Mississippi,Wayne,1142,Wayne,"20,183"
-Mississippi,Webster,409,Webster,"9,689"
-Mississippi,Wilkinson,368,Wilkinson,"8,630"
-Mississippi,Winston,1116,Winston,"17,955"
-Mississippi,Yalobusha,659,Yalobusha,"12,108"
-Mississippi,Yazoo,1455,Yazoo,"29,690"
-Missouri,Adair,976,Adair,"25,343"
-Missouri,Andrew,681,Andrew,"17,712"
-Missouri,Atchison,180,Atchison,"5,143"
-Missouri,Audrain,921,Audrain,"25,388"
-Missouri,Barry,1333,Barry,"35,789"
-Missouri,Barton,588,Barton,"11,754"
-Missouri,Bates,450,Bates,"16,172"
-Missouri,Benton,711,Benton,"19,443"
-Missouri,Bollinger,741,Bollinger,"12,133"
-Missouri,Boone,9379,Boone,"180,463"
-Missouri,Buchanan,4095,Buchanan,"87,364"
-Missouri,Butler,1891,Butler,"42,478"
-Missouri,Caldwell,334,Caldwell,"9,020"
-Missouri,Callaway,2492,Callaway,"44,743"
-Missouri,Camden,2252,Camden,"46,305"
-Missouri,Cape Girardeau,4407,CapeGirardeau,"78,871"
-Missouri,Carroll,353,Carroll,"8,679"
-Missouri,Carter,259,Carter,"5,982"
-Missouri,Cass,3281,Cass,"105,780"
-Missouri,Cedar,411,Cedar,"14,349"
-Missouri,Chariton,214,Chariton,"7,426"
-Missouri,Christian,3380,Christian,"88,595"
-Missouri,Clark,260,Clark,"6,797"
-Missouri,Clay,4115,Clay,"249,948"
-Missouri,Clinton,800,Clinton,"20,387"
-Missouri,Cole,5426,Cole,"76,745"
-Missouri,Cooper,1062,Cooper,"17,709"
-Missouri,Crawford,1056,Crawford,"23,920"
-Missouri,Dade,263,Dade,"7,561"
-Missouri,Dallas,553,Dallas,"16,878"
-Missouri,Daviess,301,Daviess,"8,278"
-Missouri,DeKalb,496,DeKalb,"12,547"
-Missouri,Dent,427,Dent,"15,573"
-Missouri,Douglas,377,Douglas,"13,185"
-Missouri,Dunklin,1558,Dunklin,"29,131"
-Missouri,Franklin,4247,Franklin,"103,967"
-Missouri,Gasconade,404,Gasconade,"14,706"
-Missouri,Gentry,355,Gentry,"6,571"
-Missouri,Greene,12531,Greene,"293,086"
-Missouri,Grundy,459,Grundy,"9,850"
-Missouri,Harrison,350,Harrison,"8,352"
-Missouri,Henry,933,Henry,"21,824"
-Missouri,Hickory,343,Hickory,"9,544"
-Missouri,Holt,226,Holt,"4,403"
-Missouri,Howard,422,Howard,"10,001"
-Missouri,Howell,1499,Howell,"40,117"
-Missouri,Iron,199,Iron,"10,125"
-Missouri,Jackson,35871,Jackson,"703,011"
-Missouri,Jasper,7548,Jasper,"121,328"
-Missouri,Jefferson,9362,Jefferson,"225,081"
-Missouri,Johnson,2261,Johnson,"54,062"
-Missouri,Knox,120,Knox,"3,959"
-Missouri,Laclede,1637,Laclede,"35,723"
-Missouri,Lafayette,1331,Lafayette,"32,708"
-Missouri,Lawrence,1742,Lawrence,"38,355"
-Missouri,Lewis,404,Lewis,"9,776"
-Missouri,Lincoln,2072,Lincoln,"59,013"
-Missouri,Linn,280,Linn,"11,920"
-Missouri,Livingston,714,Livingston,"15,227"
-Missouri,Macon,544,McDonald,"22,837"
-Missouri,Madison,736,Macon,"15,117"
-Missouri,Maries,324,Madison,"12,088"
-Missouri,Marion,1549,Maries,"8,697"
-Missouri,McDonald,1340,Marion,"28,530"
-Missouri,Mercer,68,Mercer,"3,617"
-Missouri,Miller,1369,Miller,"25,619"
-Missouri,Mississippi,684,Mississippi,"13,180"
-Missouri,Moniteau,1110,Moniteau,"16,132"
-Missouri,Monroe,326,Monroe,"8,644"
-Missouri,Montgomery,287,Montgomery,"11,551"
-Missouri,Morgan,972,Morgan,"20,627"
-Missouri,New Madrid,1204,NewMadrid,"17,076"
-Missouri,Newton,2766,Newton,"58,236"
-Missouri,Nodaway,1798,Nodaway,"22,092"
-Missouri,Oregon,343,Oregon,"10,529"
-Missouri,Osage,840,Osage,"13,615"
-Missouri,Ozark,266,Ozark,"9,174"
-Missouri,Pemiscot,1003,Pemiscot,"15,805"
-Missouri,Perry,1372,Perry,"19,136"
-Missouri,Pettis,2521,Pettis,"42,339"
-Missouri,Phelps,1449,Phelps,"44,573"
-Missouri,Pike,767,Pike,"18,302"
-Missouri,Platte,1459,Platte,"104,418"
-Missouri,Polk,1292,Polk,"32,149"
-Missouri,Pulaski,1418,Pulaski,"52,607"
-Missouri,Putnam,109,Putnam,"4,696"
-Missouri,Ralls,393,Ralls,"10,309"
-Missouri,Randolph,1075,Randolph,"24,748"
-Missouri,Ray,602,Ray,"23,018"
-Missouri,Reynolds,152,Reynolds,"6,270"
-Missouri,Ripley,448,Ripley,"13,288"
-Missouri,Saline,1442,Saline,"22,761"
-Missouri,Schuyler,118,Schuyler,"4,660"
-Missouri,Scotland,168,Scotland,"4,902"
-Missouri,Scott,2326,Scott,"38,280"
-Missouri,Shannon,320,Shannon,"8,166"
-Missouri,Shelby,172,Shelby,"5,930"
-Missouri,St. Charles,17328,StCharles,"402,022"
-Missouri,St. Clair,282,StClair,"9,397"
-Missouri,St. Francois,4499,StFrancois,"67,215"
-Missouri,St. Louis,44897,StLouis,"994,205"
-Missouri,St. Louis City,11393,StLouiscityMissouri,"300,576"
-Missouri,Ste. Genevieve,909,SteGenevieve,"17,894"
-Missouri,Stoddard,1418,Stoddard,"29,025"
-Missouri,Stone,1058,Stone,"31,952"
-Missouri,Sullivan,526,Sullivan,"6,089"
-Missouri,Taney,2523,Taney,"55,928"
-Missouri,Texas,880,Texas,"25,398"
-Missouri,Vernon,590,Vernon,"20,563"
-Missouri,Warren,1030,Warren,"35,649"
-Missouri,Washington,1256,Washington,"24,730"
-Missouri,Wayne,441,Wayne,"12,873"
-Missouri,Webster,1644,Webster,"39,592"
-Missouri,Worth,58,Worth,"2,013"
-Missouri,Wright,717,Wright,"18,289"
-Montana,Beaverhead,510,Beaverhead,"9,453"
-Montana,Big Horn,1738,BigHorn,"13,319"
-Montana,Blaine,476,Blaine,"6,681"
-Montana,Broadwater,157,Broadwater,"6,237"
-Montana,Carbon,519,Carbon,"10,725"
-Montana,Carter,105,Carter,"1,252"
-Montana,Cascade,4404,Cascade,"81,366"
-Montana,Chouteau,227,Chouteau,"5,635"
-Montana,Custer,642,Custer,"11,402"
-Montana,Daniels,88,Daniels,"1,690"
-Montana,Dawson,517,Dawson,"8,613"
-Montana,Deer Lodge,656,DeerLodge,"9,140"
-Montana,Fallon,219,Fallon,"2,846"
-Montana,Fergus,467,Fergus,"11,050"
-Montana,Flathead,5583,Flathead,"103,806"
-Montana,Gallatin,6353,Gallatin,"114,434"
-Montana,Garfield,59,Garfield,"1,258"
-Montana,Glacier,1145,Glacier,"13,753"
-Montana,Golden Valley,22,GoldenValley,821
-Montana,Granite,113,Granite,"3,379"
-Montana,Hill,1213,Hill,"16,484"
-Montana,Jefferson,392,Jefferson,"12,221"
-Montana,Judith Basin,46,JudithBasin,"2,007"
-Montana,Lake,895,Lake,"30,458"
-Montana,Lewis and Clark,2152,LewisandClark,"69,432"
-Montana,Liberty,65,Liberty,"2,337"
-Montana,Lincoln,655,Lincoln,"19,980"
-Montana,Madison,369,McCone,"1,664"
-Montana,McCone,82,Madison,"8,600"
-Montana,Meagher,103,Meagher,"1,862"
-Montana,Mineral,41,Mineral,"4,397"
-Montana,Missoula,3985,Missoula,"119,600"
-Montana,Musselshell,186,Musselshell,"4,633"
-Montana,Park,509,Park,"16,606"
-Montana,Petroleum,5,Petroleum,487
-Montana,Phillips,242,Phillips,"3,954"
-Montana,Pondera,261,Pondera,"5,911"
-Montana,Powder River,79,PowderRiver,"1,682"
-Montana,Powell,394,Powell,"6,890"
-Montana,Prairie,64,Prairie,"1,077"
-Montana,Ravalli,1157,Ravalli,"43,806"
-Montana,Richland,490,Richland,"10,803"
-Montana,Roosevelt,1170,Roosevelt,"11,004"
-Montana,Rosebud,837,Rosebud,"8,937"
-Montana,Sanders,190,Sanders,"12,113"
-Montana,Sheridan,226,Sheridan,"3,309"
-Montana,Silver Bow,1639,SilverBow,"34,915"
-Montana,Stillwater,379,Stillwater,"9,642"
-Montana,Sweet Grass,212,SweetGrass,"3,737"
-Montana,Teton,158,Teton,"6,147"
-Montana,Toole,580,Toole,"4,736"
-Montana,Treasure,28,Treasure,696
-Montana,Valley,524,Valley,"7,396"
-Montana,Wheatland,94,Wheatland,"2,126"
-Montana,Wibaux,73,Wibaux,969
-Montana,Yellowstone,9798,Yellowstone,"161,300"
-Nebraska,Adams,1449,Adams,"31,363"
-Nebraska,Antelope,291,Antelope,"6,298"
-Nebraska,Arthur,14,Arthur,463
-Nebraska,Banner,13,Banner,745
-Nebraska,Blaine,14,Blaine,465
-Nebraska,Boone,278,Boone,"5,192"
-Nebraska,Box Butte,517,BoxButte,"10,783"
-Nebraska,Boyd,112,Boyd,"1,919"
-Nebraska,Brown,149,Brown,"2,955"
-Nebraska,Buffalo,3185,Buffalo,"49,659"
-Nebraska,Burt,359,Burt,"6,459"
-Nebraska,Butler,481,Butler,"8,016"
-Nebraska,Cass,996,Cass,"26,248"
-Nebraska,Cedar,313,Cedar,"8,402"
-Nebraska,Chase,244,Chase,"3,924"
-Nebraska,Cherry,161,Cherry,"5,689"
-Nebraska,Cheyenne,398,Cheyenne,"8,910"
-Nebraska,Clay,338,Clay,"6,203"
-Nebraska,Colfax,1222,Colfax,"10,709"
-Nebraska,Cuming,543,Cuming,"8,846"
-Nebraska,Custer,409,Custer,"10,777"
-Nebraska,Dakota,2995,Dakota,"20,026"
-Nebraska,Dawes,420,Dawes,"8,589"
-Nebraska,Dawson,1828,Dawson,"23,595"
-Nebraska,Deuel,32,Deuel,"1,794"
-Nebraska,Dixon,344,Dixon,"5,636"
-Nebraska,Dodge,2569,Dodge,"36,565"
-Nebraska,Douglas,35258,Douglas,"571,327"
-Nebraska,Dundy,53,Dundy,"1,693"
-Nebraska,Fillmore,289,Fillmore,"5,462"
-Nebraska,Franklin,156,Franklin,"2,979"
-Nebraska,Frontier,96,Frontier,"2,627"
-Nebraska,Furnas,216,Furnas,"4,676"
-Nebraska,Gage,1132,Gage,"21,513"
-Nebraska,Garden,69,Garden,"1,837"
-Nebraska,Garfield,86,Garfield,"1,969"
-Nebraska,Gosper,101,Gosper,"1,990"
-Nebraska,Grant,16,Grant,623
-Nebraska,Greeley,109,Greeley,"2,356"
-Nebraska,Hall,4065,Hall,"61,353"
-Nebraska,Hamilton,457,Hamilton,"9,324"
-Nebraska,Harlan,115,Harlan,"3,380"
-Nebraska,Hayes,38,Hayes,922
-Nebraska,Hitchcock,84,Hitchcock,"2,762"
-Nebraska,Holt,486,Holt,"10,067"
-Nebraska,Hooker,42,Hooker,682
-Nebraska,Howard,313,Howard,"6,445"
-Nebraska,Jefferson,280,Jefferson,"7,046"
-Nebraska,Johnson,300,Johnson,"5,071"
-Nebraska,Kearney,448,Kearney,"6,495"
-Nebraska,Keith,301,Keith,"8,034"
-Nebraska,Keya Paha,17,KeyaPaha,806
-Nebraska,Kimball,147,Kimball,"3,632"
-Nebraska,Knox,392,Knox,"8,332"
-Nebraska,Lancaster,14150,Lancaster,"319,090"
-Nebraska,Lincoln,1956,Lincoln,"34,914"
-Nebraska,Logan,32,Logan,748
-Nebraska,Loup,27,Loup,664
-Nebraska,Madison,2808,McPherson,494
-Nebraska,McPherson,15,Madison,"35,099"
-Nebraska,Merrick,395,Merrick,"7,755"
-Nebraska,Morrill,275,Morrill,"4,642"
-Nebraska,Nance,235,Nance,"3,519"
-Nebraska,Nemaha,276,Nemaha,"6,972"
-Nebraska,Nuckolls,179,Nuckolls,"4,148"
-Nebraska,Otoe,663,Otoe,"16,012"
-Nebraska,Pawnee,66,Pawnee,"2,613"
-Nebraska,Perkins,118,Perkins,"2,891"
-Nebraska,Phelps,486,Phelps,"9,034"
-Nebraska,Pierce,389,Pierce,"7,148"
-Nebraska,Platte,2863,Platte,"33,470"
-Nebraska,Polk,295,Polk,"5,213"
-Nebraska,Red Willow,507,RedWillow,"10,724"
-Nebraska,Richardson,290,Richardson,"7,865"
-Nebraska,Rock,75,Rock,"1,357"
-Nebraska,Saline,1347,Saline,"14,224"
-Nebraska,Sarpy,10021,Sarpy,"187,196"
-Nebraska,Saunders,1100,Saunders,"21,578"
-Nebraska,Scotts Bluff,2493,ScottsBluff,"35,618"
-Nebraska,Seward,725,Seward,"17,284"
-Nebraska,Sheridan,259,Sheridan,"5,246"
-Nebraska,Sherman,108,Sherman,"3,001"
-Nebraska,Sioux,18,Sioux,"1,166"
-Nebraska,Stanton,178,Stanton,"5,920"
-Nebraska,Thayer,208,Thayer,"5,003"
-Nebraska,Thomas,27,Thomas,722
-Nebraska,Thurston,515,Thurston,"7,224"
-Nebraska,Valley,165,Valley,"4,158"
-Nebraska,Washington,1002,Washington,"20,729"
-Nebraska,Wayne,674,Wayne,"9,385"
-Nebraska,Webster,173,Webster,"3,487"
-Nebraska,Wheeler,11,Wheeler,783
-Nebraska,York,875,York,"13,679"
-Nevada,Carson City,1545,CarsonCityNevada,"55,916"
-Nevada,Churchill,638,Churchill,"24,909"
-Nevada,Clark,101933,Clark,"2,266,715"
-Nevada,Douglas,516,Douglas,"48,905"
-Nevada,Elko,2207,Elko,"52,778"
-Nevada,Esmeralda,5,Esmeralda,873
-Nevada,Eureka,22,Eureka,"2,029"
-Nevada,Humboldt,263,Humboldt,"16,831"
-Nevada,Lander,156,Lander,"5,532"
-Nevada,Lincoln,162,Lincoln,"5,183"
-Nevada,Lyon,743,Lyon,"57,510"
-Nevada,Mineral,61,Mineral,"4,505"
-Nevada,Nye,1122,Nye,"46,523"
-Nevada,Pershing,46,Pershing,"6,725"
-Nevada,Storey,31,Storey,"4,123"
-Nevada,Washoe,20046,Washoe,"471,519"
-Nevada,White Pine,218,WhitePine,"9,580"
-New Hampshire,Belknap,510,Belknap,"61,303"
-New Hampshire,Carroll,284,Carroll,"48,910"
-New Hampshire,Cheshire,407,Cheshire,"76,085"
-New Hampshire,Coos,268,Coos,"31,563"
-New Hampshire,Grafton,452,Grafton,"89,886"
-New Hampshire,Hillsborough,7375,Hillsborough,"417,025"
-New Hampshire,Merrimack,1439,Merrimack,"151,391"
-New Hampshire,Rockingham,4013,Rockingham,"309,769"
-New Hampshire,Strafford,1367,Strafford,"130,633"
-New Hampshire,Sullivan,186,Sullivan,"43,146"
-New Jersey,Atlantic,7023,Atlantic,"263,670"
-New Jersey,Bergen,31006,Bergen,"932,202"
-New Jersey,Burlington,11411,Burlington,"445,349"
-New Jersey,Camden,16103,Camden,"506,471"
-New Jersey,Cape May,1498,CapeMay,"92,039"
-New Jersey,Cumberland,4636,Cumberland,"149,527"
-New Jersey,Essex,31902,Essex,"798,975"
-New Jersey,Gloucester,7718,Gloucester,"291,636"
-New Jersey,Hudson,28370,Hudson,"672,391"
-New Jersey,Hunterdon,2155,Hunterdon,"124,371"
-New Jersey,Mercer,12087,Mercer,"367,430"
-New Jersey,Middlesex,27418,Middlesex,"825,062"
-New Jersey,Monmouth,18006,Monmouth,"618,795"
-New Jersey,Morris,11883,Morris,"491,845"
-New Jersey,Ocean,19648,Ocean,"607,186"
-New Jersey,Passaic,26415,Passaic,"501,826"
-New Jersey,Salem,1442,Salem,"62,385"
-New Jersey,Somerset,8146,Somerset,"328,934"
-New Jersey,Sussex,2245,Sussex,"140,488"
-New Jersey,Union,25437,Union,"556,341"
-New Jersey,Warren,2181,Warren,"105,267"
-New Mexico,Bernalillo,20539,Bernalillo,"679,121"
-New Mexico,Catron,29,Catron,"3,527"
-New Mexico,Chaves,3726,Chaves,"64,615"
-New Mexico,Cibola,1261,Cibola,"26,675"
-New Mexico,Colfax,127,Colfax,"11,941"
-New Mexico,Curry,2705,Curry,"48,954"
-New Mexico,De Baca,30,DeBaca,"1,748"
-New Mexico,Dona Ana,11567,DoñaAna,"218,195"
-New Mexico,Eddy,2436,Eddy,"58,460"
-New Mexico,Grant,397,Grant,"26,998"
-New Mexico,Guadalupe,93,Guadalupe,"4,300"
-New Mexico,Harding,4,Harding,625
-New Mexico,Hidalgo,157,Hidalgo,"4,198"
-New Mexico,Lea,3451,Lea,"71,070"
-New Mexico,Lincoln,606,Lincoln,"19,572"
-New Mexico,Los Alamos,106,LosAlamos,"19,369"
-New Mexico,Luna,1694,Luna,"23,709"
-New Mexico,McKinley,5778,McKinley,"71,367"
-New Mexico,Mora,31,Mora,"4,521"
-New Mexico,Otero,1146,Otero,"67,490"
-New Mexico,Quay,178,Quay,"8,253"
-New Mexico,Rio Arriba,1028,RioArriba,"38,921"
-New Mexico,Roosevelt,843,Roosevelt,"18,500"
-New Mexico,San Juan,4807,Sandoval,"146,748"
-New Mexico,San Miguel,340,SanJuan,"123,958"
-New Mexico,Sandoval,3797,SanMiguel,"27,277"
-New Mexico,Santa Fe,3977,SantaFe,"150,358"
-New Mexico,Sierra,227,Sierra,"10,791"
-New Mexico,Socorro,494,Socorro,"16,637"
-New Mexico,Taos,636,Taos,"32,723"
-New Mexico,Torrance,205,Torrance,"15,461"
-New Mexico,Union,90,Union,"4,059"
-New Mexico,Valencia,2155,Valencia,"76,688"
-New York,Albany,4906,Albany,"305,506"
-New York,Allegany,758,Allegany,"46,091"
-New York,Bronx,60233,Bronx,"1,418,207"
-New York,Broome,4688,Broome,"190,488"
-New York,Cattaraugus,809,Cattaraugus,"76,117"
-New York,Cayuga,681,Cayuga,"76,576"
-New York,Chautauqua,1351,Chautauqua,"126,903"
-New York,Chemung,2518,Chemung,"83,456"
-New York,Chenango,542,Chenango,"47,207"
-New York,Clinton,406,Clinton,"80,485"
-New York,Columbia,934,Columbia,"59,461"
-New York,Cortland,839,Cortland,"47,581"
-New York,Delaware,297,Delaware,"44,135"
-New York,Dutchess,6493,Dutchess,"294,218"
-New York,Erie,20103,Erie,"918,702"
-New York,Essex,240,Essex,"36,885"
-New York,Franklin,220,Franklin,"50,022"
-New York,Fulton,416,Fulton,"53,383"
-New York,Genesee,695,Genesee,"57,280"
-New York,Greene,604,Greene,"47,188"
-New York,Hamilton,35,Hamilton,"4,416"
-New York,Herkimer,552,Herkimer,"61,319"
-New York,Jefferson,376,Jefferson,"109,834"
-New York,Kings,83608,Kings,"2,559,903"
-New York,Lewis,284,Lewis,"26,296"
-New York,Livingston,549,Livingston,"62,914"
-New York,Madison,776,Madison,"70,941"
-New York,Monroe,11733,Monroe,"741,770"
-New York,Montgomery,364,Montgomery,"49,221"
-New York,Nassau,55875,Nassau,"1,356,924"
-New York,New York,41620,NewYork,"1,628,706"
-New York,Niagara,3023,Niagara,"209,281"
-New York,Oneida,3896,Oneida,"228,671"
-New York,Onondaga,8735,Onondaga,"460,528"
-New York,Ontario,1039,Ontario,"109,777"
-New York,Orange,15677,Orange,"384,940"
-New York,Orleans,550,Orleans,"40,352"
-New York,Oswego,1101,Oswego,"117,124"
-New York,Otsego,497,Otsego,"59,493"
-New York,Putnam,2308,Putnam,"98,320"
-New York,Queens,84843,Queens,"2,253,858"
-New York,Rensselaer,1449,Rensselaer,"158,714"
-New York,Richmond,20586,Richmond,"476,143"
-New York,Rockland,20351,Rockland,"325,789"
-New York,Saratoga,1842,StLawrence,"107,740"
-New York,Schenectady,1997,Saratoga,"229,863"
-New York,Schoharie,162,Schenectady,"155,299"
-New York,Schuyler,248,Schoharie,"30,999"
-New York,Seneca,232,Schuyler,"17,807"
-New York,St. Lawrence,649,Seneca,"34,016"
-New York,Steuben,1502,Steuben,"95,379"
-New York,Suffolk,55329,Suffolk,"1,476,601"
-New York,Sullivan,2044,Sullivan,"75,432"
-New York,Tioga,998,Tioga,"48,203"
-New York,Tompkins,848,Tompkins,"102,180"
-New York,Ulster,2969,Ulster,"177,573"
-New York,Warren,530,Warren,"63,944"
-New York,Washington,414,Washington,"61,204"
-New York,Wayne,858,Wayne,"89,918"
-New York,Westchester,46064,Westchester,"967,506"
-New York,Wyoming,384,Wyoming,"39,859"
-New York,Yates,220,Yates,"24,913"
-North Carolina,Alamance,6429,Alamance,"169,509"
-North Carolina,Alexander,1396,Alexander,"37,497"
-North Carolina,Alleghany,370,Alleghany,"11,137"
-North Carolina,Anson,848,Anson,"24,446"
-North Carolina,Ashe,693,Ashe,"27,203"
-North Carolina,Avery,838,Avery,"17,557"
-North Carolina,Beaufort,1600,Beaufort,"46,994"
-North Carolina,Bertie,828,Bertie,"18,947"
-North Carolina,Bladen,1244,Bladen,"32,722"
-North Carolina,Brunswick,2696,Brunswick,"142,820"
-North Carolina,Buncombe,5075,Buncombe,"261,191"
-North Carolina,Burke,3425,Burke,"90,485"
-North Carolina,Cabarrus,6197,Cabarrus,"216,453"
-North Carolina,Caldwell,3187,Caldwell,"82,178"
-North Carolina,Camden,167,Camden,"10,867"
-North Carolina,Carteret,1539,Carteret,"69,473"
-North Carolina,Caswell,766,Caswell,"22,604"
-North Carolina,Catawba,6056,Catawba,"159,551"
-North Carolina,Chatham,2248,Chatham,"74,470"
-North Carolina,Cherokee,887,Cherokee,"28,612"
-North Carolina,Chowan,579,Chowan,"13,943"
-North Carolina,Clay,269,Clay,"11,231"
-North Carolina,Cleveland,3916,Cleveland,"97,947"
-North Carolina,Columbus,2404,Columbus,"55,508"
-North Carolina,Craven,2842,Craven,"102,139"
-North Carolina,Cumberland,8672,Cumberland,"335,509"
-North Carolina,Currituck,301,Currituck,"27,763"
-North Carolina,Dare,574,Dare,"37,009"
-North Carolina,Davidson,4730,Davidson,"167,609"
-North Carolina,Davie,1074,Davie,"42,846"
-North Carolina,Duplin,3177,Duplin,"58,741"
-North Carolina,Durham,10575,Durham,"321,488"
-North Carolina,Edgecombe,2365,Edgecombe,"51,472"
-North Carolina,Forsyth,11723,Forsyth,"382,295"
-North Carolina,Franklin,1798,Franklin,"69,685"
-North Carolina,Gaston,9338,Gaston,"224,529"
-North Carolina,Gates,190,Gates,"11,562"
-North Carolina,Graham,268,Graham,"8,441"
-North Carolina,Granville,2362,Granville,"60,443"
-North Carolina,Greene,1128,Greene,"21,069"
-North Carolina,Guilford,14942,Guilford,"537,174"
-North Carolina,Halifax,1812,Halifax,"50,010"
-North Carolina,Harnett,3635,Harnett,"135,976"
-North Carolina,Haywood,963,Haywood,"62,317"
-North Carolina,Henderson,2908,Henderson,"117,417"
-North Carolina,Hertford,934,Hertford,"23,677"
-North Carolina,Hoke,1848,Hoke,"55,234"
-North Carolina,Hyde,181,Hyde,"4,937"
-North Carolina,Iredell,4874,Iredell,"181,806"
-North Carolina,Jackson,1315,Jackson,"43,938"
-North Carolina,Johnston,6988,Johnston,"209,339"
-North Carolina,Jones,232,Jones,"9,419"
-North Carolina,Lee,2350,Lee,"61,779"
-North Carolina,Lenoir,1910,Lenoir,"55,949"
-North Carolina,Lincoln,3081,Lincoln,"86,111"
-North Carolina,Macon,886,McDowell,"45,756"
-North Carolina,Madison,428,Macon,"35,858"
-North Carolina,Martin,774,Madison,"21,755"
-North Carolina,McDowell,1647,Martin,"22,440"
-North Carolina,Mecklenburg,39880,Mecklenburg,"1,110,356"
-North Carolina,Mitchell,447,Mitchell,"14,964"
-North Carolina,Montgomery,1324,Montgomery,"27,173"
-North Carolina,Moore,2677,Moore,"100,880"
-North Carolina,Nash,4130,Nash,"94,298"
-North Carolina,New Hanover,6421,NewHanover,"234,473"
-North Carolina,Northampton,709,Northampton,"19,483"
-North Carolina,Onslow,4553,Onslow,"197,938"
-North Carolina,Orange,3648,Orange,"148,476"
-North Carolina,Pamlico,359,Pamlico,"12,726"
-North Carolina,Pasquotank,1013,Pasquotank,"39,824"
-North Carolina,Pender,1713,Pender,"63,060"
-North Carolina,Perquimans,308,Perquimans,"13,463"
-North Carolina,Person,865,Person,"39,490"
-North Carolina,Pitt,7285,Pitt,"180,742"
-North Carolina,Polk,449,Polk,"20,724"
-North Carolina,Randolph,4878,Randolph,"143,667"
-North Carolina,Richmond,1728,Richmond,"44,829"
-North Carolina,Robeson,6915,Robeson,"130,625"
-North Carolina,Rockingham,2710,Rockingham,"91,010"
-North Carolina,Rowan,5133,Rowan,"142,088"
-North Carolina,Rutherford,2136,Rutherford,"67,029"
-North Carolina,Sampson,3367,Sampson,"63,531"
-North Carolina,Scotland,1833,Scotland,"34,823"
-North Carolina,Stanly,2764,Stanly,"62,806"
-North Carolina,Stokes,1002,Stokes,"45,591"
-North Carolina,Surry,2526,Surry,"71,783"
-North Carolina,Swain,359,Swain,"14,271"
-North Carolina,Transylvania,502,Transylvania,"34,385"
-North Carolina,Tyrrell,137,Tyrrell,"4,016"
-North Carolina,Union,7130,Union,"239,859"
-North Carolina,Vance,1533,Vance,"44,535"
-North Carolina,Wake,25975,Wake,"1,111,761"
-North Carolina,Warren,571,Warren,"19,731"
-North Carolina,Washington,294,Washington,"11,580"
-North Carolina,Watauga,1679,Watauga,"56,177"
-North Carolina,Wayne,5357,Wayne,"123,131"
-North Carolina,Wilkes,2422,Wilkes,"68,412"
-North Carolina,Wilson,3709,Wilson,"81,801"
-North Carolina,Yadkin,1341,Yadkin,"37,667"
-North Carolina,Yancey,476,Yancey,"18,069"
-North Dakota,Adams,149,Adams,"2,216"
-North Dakota,Barnes,865,Barnes,"10,415"
-North Dakota,Benson,699,Benson,"6,832"
-North Dakota,Billings,38,Billings,928
-North Dakota,Bottineau,479,Bottineau,"6,282"
-North Dakota,Bowman,177,Bowman,"3,024"
-North Dakota,Burke,161,Burke,"2,115"
-North Dakota,Burleigh,10658,Burleigh,"95,626"
-North Dakota,Cass,14630,Cass,"181,923"
-North Dakota,Cavalier,299,Cavalier,"3,762"
-North Dakota,Dickey,509,Dickey,"4,872"
-North Dakota,Divide,115,Divide,"2,264"
-North Dakota,Dunn,273,Dunn,"4,424"
-North Dakota,Eddy,337,Eddy,"2,287"
-North Dakota,Emmons,325,Emmons,"3,241"
-North Dakota,Foster,410,Foster,"3,210"
-North Dakota,Golden Valley,146,GoldenValley,"1,761"
-North Dakota,Grand Forks,7475,GrandForks,"69,451"
-North Dakota,Grant,138,Grant,"2,274"
-North Dakota,Griggs,198,Griggs,"2,231"
-North Dakota,Hettinger,208,Hettinger,"2,499"
-North Dakota,Kidder,164,Kidder,"2,480"
-North Dakota,LaMoure,321,LaMoure,"4,046"
-North Dakota,Logan,151,Logan,"1,850"
-North Dakota,McHenry,408,McHenry,"5,745"
-North Dakota,McIntosh,226,McIntosh,"2,497"
-North Dakota,McKenzie,805,McKenzie,"15,024"
-North Dakota,McLean,885,McLean,"9,450"
-North Dakota,Mercer,778,Mercer,"8,187"
-North Dakota,Morton,3625,Morton,"31,364"
-North Dakota,Mountrail,960,Mountrail,"10,545"
-North Dakota,Nelson,319,Nelson,"2,879"
-North Dakota,Oliver,115,Oliver,"1,959"
-North Dakota,Pembina,525,Pembina,"6,801"
-North Dakota,Pierce,342,Pierce,"3,975"
-North Dakota,Ramsey,1002,Ramsey,"11,519"
-North Dakota,Ransom,383,Ransom,"5,218"
-North Dakota,Renville,185,Renville,"2,327"
-North Dakota,Richland,970,Richland,"16,177"
-North Dakota,Rolette,1227,Rolette,"14,176"
-North Dakota,Sargent,248,Sargent,"3,898"
-North Dakota,Sheridan,73,Sheridan,"1,315"
-North Dakota,Sioux,398,Sioux,"4,230"
-North Dakota,Slope,19,Slope,750
-North Dakota,Stark,3234,Stark,"31,489"
-North Dakota,Steele,107,Steele,"1,890"
-North Dakota,Stutsman,2294,Stutsman,"20,704"
-North Dakota,Towner,187,Towner,"2,189"
-North Dakota,Traill,622,Traill,"8,036"
-North Dakota,Walsh,1310,Walsh,"10,641"
-North Dakota,Ward,6802,Ward,"67,641"
-North Dakota,Wells,283,Wells,"3,834"
-North Dakota,Williams,2759,Williams,"37,589"
-Ohio,Adams,678,Adams,"27,698"
-Ohio,Allen,4353,Allen,"102,351"
-Ohio,Ashland,920,Ashland,"53,484"
-Ohio,Ashtabula,1915,Ashtabula,"97,241"
-Ohio,Athens,1730,Athens,"65,327"
-Ohio,Auglaize,2107,Auglaize,"45,656"
-Ohio,Belmont,1462,Belmont,"67,006"
-Ohio,Brown,866,Brown,"43,432"
-Ohio,Butler,13610,Butler,"383,134"
-Ohio,Carroll,398,Carroll,"26,914"
-Ohio,Champaign,850,Champaign,"38,885"
-Ohio,Clark,4633,Clark,"134,083"
-Ohio,Clermont,5135,Clermont,"206,428"
-Ohio,Clinton,964,Clinton,"41,968"
-Ohio,Columbiana,3165,Columbiana,"101,883"
-Ohio,Coshocton,757,Coshocton,"36,600"
-Ohio,Crawford,1072,Crawford,"41,494"
-Ohio,Cuyahoga,32296,Cuyahoga,"1,235,072"
-Ohio,Darke,1999,Darke,"51,113"
-Ohio,Defiance,1250,Defiance,"38,087"
-Ohio,Delaware,4881,Delaware,"209,177"
-Ohio,Erie,1945,Erie,"74,266"
-Ohio,Fairfield,4823,Fairfield,"157,574"
-Ohio,Fayette,840,Fayette,"28,525"
-Ohio,Franklin,46473,Franklin,"1,316,756"
-Ohio,Fulton,1123,Fulton,"42,126"
-Ohio,Gallia,601,Gallia,"29,898"
-Ohio,Geauga,1776,Geauga,"93,649"
-Ohio,Greene,4710,Greene,"168,937"
-Ohio,Guernsey,759,Guernsey,"38,875"
-Ohio,Hamilton,27724,Hamilton,"817,473"
-Ohio,Hancock,2093,Hancock,"75,783"
-Ohio,Hardin,781,Hardin,"31,365"
-Ohio,Harrison,171,Harrison,"15,040"
-Ohio,Henry,890,Henry,"27,006"
-Ohio,Highland,923,Highland,"43,161"
-Ohio,Hocking,542,Hocking,"28,264"
-Ohio,Holmes,1328,Holmes,"43,960"
-Ohio,Huron,1325,Huron,"58,266"
-Ohio,Jackson,830,Jackson,"32,413"
-Ohio,Jefferson,957,Jefferson,"65,325"
-Ohio,Knox,1100,Knox,"62,322"
-Ohio,Lake,5861,Lake,"230,149"
-Ohio,Lawrence,1733,Lawrence,"59,463"
-Ohio,Licking,4806,Licking,"176,862"
-Ohio,Logan,1089,Logan,"45,672"
-Ohio,Lorain,5565,Lorain,"309,833"
-Ohio,Lucas,13035,Lucas,"428,348"
-Ohio,Madison,1447,Madison,"44,731"
-Ohio,Mahoning,6459,Mahoning,"228,683"
-Ohio,Marion,4374,Marion,"65,093"
-Ohio,Medina,3875,Medina,"179,746"
-Ohio,Meigs,337,Meigs,"22,907"
-Ohio,Mercer,2745,Mercer,"41,172"
-Ohio,Miami,3813,Miami,"106,987"
-Ohio,Monroe,280,Monroe,"13,654"
-Ohio,Montgomery,18176,Montgomery,"531,687"
-Ohio,Morgan,208,Morgan,"14,508"
-Ohio,Morrow,780,Morrow,"35,328"
-Ohio,Muskingum,2100,Muskingum,"86,215"
-Ohio,Noble,538,Noble,"14,424"
-Ohio,Ottawa,1090,Ottawa,"40,525"
-Ohio,Paulding,565,Paulding,"18,672"
-Ohio,Perry,688,Perry,"36,134"
-Ohio,Pickaway,3813,Pickaway,"58,457"
-Ohio,Pike,661,Pike,"27,772"
-Ohio,Portage,3027,Portage,"162,466"
-Ohio,Preble,1367,Preble,"40,882"
-Ohio,Putnam,2125,Putnam,"33,861"
-Ohio,Richland,2726,Richland,"121,154"
-Ohio,Ross,2253,Ross,"76,666"
-Ohio,Sandusky,1370,Sandusky,"58,518"
-Ohio,Scioto,1773,Scioto,"75,314"
-Ohio,Seneca,1563,Seneca,"55,178"
-Ohio,Shelby,1678,Shelby,"48,590"
-Ohio,Stark,7655,Stark,"370,606"
-Ohio,Summit,11890,Summit,"541,013"
-Ohio,Trumbull,4682,Trumbull,"197,974"
-Ohio,Tuscarawas,2874,Tuscarawas,"91,987"
-Ohio,Union,1707,Union,"58,988"
-Ohio,Van Wert,811,VanWert,"28,275"
-Ohio,Vinton,197,Vinton,"13,085"
-Ohio,Warren,7373,Warren,"234,602"
-Ohio,Washington,967,Washington,"59,911"
-Ohio,Wayne,2933,Wayne,"115,710"
-Ohio,Williams,953,Williams,"36,692"
-Ohio,Wood,4083,Wood,"130,817"
-Ohio,Wyandot,623,Wyandot,"21,772"
-Oklahoma,Adair,1115,Adair,"22,194"
-Oklahoma,Alfalfa,271,Alfalfa,"5,702"
-Oklahoma,Atoka,748,Atoka,"13,758"
-Oklahoma,Beaver,154,Beaver,"5,311"
-Oklahoma,Beckham,1146,Beckham,"21,859"
-Oklahoma,Blaine,306,Blaine,"9,429"
-Oklahoma,Bryan,2508,Bryan,"47,995"
-Oklahoma,Caddo,1566,Caddo,"28,762"
-Oklahoma,Canadian,5913,Canadian,"148,306"
-Oklahoma,Carter,1355,Carter,"48,111"
-Oklahoma,Cherokee,1954,Cherokee,"48,657"
-Oklahoma,Choctaw,628,Choctaw,"14,672"
-Oklahoma,Cimarron,60,Cimarron,"2,137"
-Oklahoma,Cleveland,11158,Cleveland,"284,014"
-Oklahoma,Coal,237,Coal,"5,495"
-Oklahoma,Comanche,3901,Comanche,"120,749"
-Oklahoma,Cotton,176,Cotton,"5,666"
-Oklahoma,Craig,828,Craig,"14,142"
-Oklahoma,Creek,2263,Creek,"71,522"
-Oklahoma,Custer,1598,Custer,"29,003"
-Oklahoma,Delaware,1719,Delaware,"43,009"
-Oklahoma,Dewey,158,Dewey,"4,891"
-Oklahoma,Ellis,111,Ellis,"3,859"
-Oklahoma,Garfield,3224,Garfield,"61,056"
-Oklahoma,Garvin,1348,Garvin,"27,711"
-Oklahoma,Grady,2288,Grady,"55,834"
-Oklahoma,Grant,187,Grant,"4,333"
-Oklahoma,Greer,213,Greer,"5,712"
-Oklahoma,Harmon,95,Harmon,"2,653"
-Oklahoma,Harper,139,Harper,"3,688"
-Oklahoma,Haskell,595,Haskell,"12,627"
-Oklahoma,Hughes,537,Hughes,"13,279"
-Oklahoma,Jackson,1612,Jackson,"24,530"
-Oklahoma,Jefferson,152,Jefferson,"6,002"
-Oklahoma,Johnston,456,Johnston,"11,085"
-Oklahoma,Kay,1465,Kay,"43,538"
-Oklahoma,Kingfisher,773,Kingfisher,"15,765"
-Oklahoma,Kiowa,284,Kiowa,"8,708"
-Oklahoma,Latimer,288,Latimer,"10,073"
-Oklahoma,Le Flore,2213,LeFlore,"49,853"
-Oklahoma,Lincoln,1152,Lincoln,"34,877"
-Oklahoma,Logan,1197,Logan,"48,011"
-Oklahoma,Love,480,Love,"10,253"
-Oklahoma,Major,367,McClain,"40,474"
-Oklahoma,Marshall,581,McCurtain,"32,832"
-Oklahoma,Mayes,1358,McIntosh,"19,596"
-Oklahoma,McClain,2097,Major,"7,629"
-Oklahoma,McCurtain,2143,Marshall,"16,931"
-Oklahoma,McIntosh,719,Mayes,"41,100"
-Oklahoma,Murray,529,Murray,"14,073"
-Oklahoma,Muskogee,3757,Muskogee,"67,997"
-Oklahoma,Noble,350,Noble,"11,131"
-Oklahoma,Nowata,364,Nowata,"10,076"
-Oklahoma,Okfuskee,882,Okfuskee,"11,993"
-Oklahoma,Oklahoma,33851,Oklahoma,"797,434"
-Oklahoma,Okmulgee,1633,Okmulgee,"38,465"
-Oklahoma,Osage,1774,Osage,"46,963"
-Oklahoma,Ottawa,1573,Ottawa,"31,127"
-Oklahoma,Pawnee,488,Pawnee,"16,376"
-Oklahoma,Payne,3745,Payne,"81,784"
-Oklahoma,Pittsburg,1713,Pittsburg,"43,654"
-Oklahoma,Pontotoc,1579,Pontotoc,"38,284"
-Oklahoma,Pottawatomie,2988,Pottawatomie,"72,592"
-Oklahoma,Pushmataha,389,Pushmataha,"11,096"
-Oklahoma,Roger Mills,134,RogerMills,"3,583"
-Oklahoma,Rogers,3535,Rogers,"92,459"
-Oklahoma,Seminole,1125,Seminole,"24,258"
-Oklahoma,Sequoyah,1664,Sequoyah,"41,569"
-Oklahoma,Stephens,1312,Stephens,"43,143"
-Oklahoma,Texas,2177,Texas,"19,983"
-Oklahoma,Tillman,268,Tillman,"7,250"
-Oklahoma,Tulsa,28966,Tulsa,"651,552"
-Oklahoma,Wagoner,2437,Wagoner,"81,289"
-Oklahoma,Washington,1749,Washington,"51,527"
-Oklahoma,Washita,302,Washita,"10,916"
-Oklahoma,Woods,410,Woods,"8,793"
-Oklahoma,Woodward,1644,Woodward,"20,211"
-Oregon,Baker,248,Baker,"16,124"
-Oregon,Benton,679,Benton,"93,053"
-Oregon,Clackamas,5025,Clackamas,"418,187"
-Oregon,Clatsop,321,Clatsop,"40,224"
-Oregon,Columbia,405,Columbia,"52,354"
-Oregon,Coos,368,Coos,"64,487"
-Oregon,Crook,183,Crook,"24,404"
-Oregon,Curry,101,Curry,"22,925"
-Oregon,Deschutes,1841,Deschutes,"197,692"
-Oregon,Douglas,756,Douglas,"110,980"
-Oregon,Gilliam,21,Gilliam,"1,912"
-Oregon,Grant,101,Grant,"7,199"
-Oregon,Harney,82,Harney,"7,393"
-Oregon,Hood River,349,HoodRiver,"23,382"
-Oregon,Jackson,3240,Jackson,"220,944"
-Oregon,Jefferson,749,Jefferson,"24,658"
-Oregon,Josephine,401,Josephine,"87,487"
-Oregon,Klamath,612,Klamath,"68,238"
-Oregon,Lake,85,Lake,"7,869"
-Oregon,Lane,3672,Lane,"382,067"
-Oregon,Lincoln,559,Lincoln,"49,962"
-Oregon,Linn,1188,Linn,"129,749"
-Oregon,Malheur,2265,Malheur,"30,571"
-Oregon,Marion,8025,Marion,"347,818"
-Oregon,Morrow,602,Morrow,"11,603"
-Oregon,Multnomah,14060,Multnomah,"812,855"
-Oregon,Polk,983,Polk,"86,085"
-Oregon,Sherman,23,Sherman,"1,780"
-Oregon,Tillamook,111,Tillamook,"27,036"
-Oregon,Umatilla,4013,Umatilla,"77,950"
-Oregon,Union,655,Union,"26,835"
-Oregon,Wallowa,70,Wallowa,"7,208"
-Oregon,Wasco,447,Wasco,"26,682"
-Oregon,Washington,8466,Washington,"601,592"
-Oregon,Wheeler,1,Wheeler,"1,332"
-Oregon,Yamhill,1468,Yamhill,"107,100"
-Pennsylvania,Adams,1636,Adams,"103,009"
-Pennsylvania,Allegheny,22527,Allegheny,"1,216,045"
-Pennsylvania,Armstrong,1441,Armstrong,"64,735"
-Pennsylvania,Beaver,3154,Beaver,"163,929"
-Pennsylvania,Bedford,1113,Bedford,"47,888"
-Pennsylvania,Berks,12215,Berks,"421,164"
-Pennsylvania,Blair,3105,Blair,"121,829"
-Pennsylvania,Bradford,1605,Bradford,"60,323"
-Pennsylvania,Bucks,14465,Bucks,"628,270"
-Pennsylvania,Butler,3426,Butler,"187,853"
-Pennsylvania,Cambria,2877,Cambria,"130,192"
-Pennsylvania,Cameron,17,Cameron,"4,447"
-Pennsylvania,Carbon,1008,Carbon,"64,182"
-Pennsylvania,Centre,5502,Centre,"162,385"
-Pennsylvania,Chester,10505,Chester,"524,989"
-Pennsylvania,Clarion,651,Clarion,"38,438"
-Pennsylvania,Clearfield,1076,Clearfield,"79,255"
-Pennsylvania,Clinton,490,Clinton,"38,632"
-Pennsylvania,Columbia,1309,Columbia,"64,964"
-Pennsylvania,Crawford,1362,Crawford,"84,629"
-Pennsylvania,Cumberland,4017,Cumberland,"253,370"
-Pennsylvania,Dauphin,6637,Dauphin,"278,299"
-Pennsylvania,Delaware,17899,Delaware,"566,747"
-Pennsylvania,Elk,407,Elk,"29,910"
-Pennsylvania,Erie,4096,Erie,"269,728"
-Pennsylvania,Fayette,1596,Fayette,"129,274"
-Pennsylvania,Forest,51,Forest,"7,247"
-Pennsylvania,Franklin,3582,Franklin,"155,027"
-Pennsylvania,Fulton,198,Fulton,"14,530"
-Pennsylvania,Greene,558,Greene,"36,233"
-Pennsylvania,Huntingdon,1488,Huntingdon,"45,144"
-Pennsylvania,Indiana,2062,Indiana,"84,073"
-Pennsylvania,Jefferson,521,Jefferson,"43,425"
-Pennsylvania,Juniata,535,Juniata,"24,763"
-Pennsylvania,Lackawanna,4597,Lackawanna,"209,674"
-Pennsylvania,Lancaster,13564,Lancaster,"545,724"
-Pennsylvania,Lawrence,1776,Lawrence,"85,512"
-Pennsylvania,Lebanon,4444,Lebanon,"141,793"
-Pennsylvania,Lehigh,9453,Lehigh,"369,318"
-Pennsylvania,Luzerne,7966,Luzerne,"317,417"
-Pennsylvania,Lycoming,1580,Lycoming,"113,299"
-Pennsylvania,McKean,332,McKean,"40,625"
-Pennsylvania,Mercer,2198,Mercer,"109,424"
-Pennsylvania,Mifflin,1202,Mifflin,"46,138"
-Pennsylvania,Monroe,2782,Monroe,"170,271"
-Pennsylvania,Montgomery,18861,Montgomery,"830,915"
-Pennsylvania,Montour,399,Montour,"18,230"
-Pennsylvania,Northampton,7472,Northampton,"305,285"
-Pennsylvania,Northumberland,2118,Northumberland,"90,843"
-Pennsylvania,Perry,553,Perry,"46,272"
-Pennsylvania,Philadelphia,59081,Philadelphia,"1,584,064"
-Pennsylvania,Pike,774,Pike,"55,809"
-Pennsylvania,Potter,125,Potter,"16,526"
-Pennsylvania,Schuylkill,3240,Schuylkill,"141,359"
-Pennsylvania,Snyder,819,Snyder,"40,372"
-Pennsylvania,Somerset,1165,Somerset,"73,447"
-Pennsylvania,Sullivan,41,Sullivan,"6,066"
-Pennsylvania,Susquehanna,535,Susquehanna,"40,328"
-Pennsylvania,Tioga,658,Tioga,"40,591"
-Pennsylvania,Union,1187,Union,"44,923"
-Pennsylvania,Venango,674,Venango,"50,668"
-Pennsylvania,Warren,154,Warren,"39,191"
-Pennsylvania,Washington,3596,Washington,"206,865"
-Pennsylvania,Wayne,383,Wayne,"51,361"
-Pennsylvania,Westmoreland,7097,Westmoreland,"348,899"
-Pennsylvania,Wyoming,372,Wyoming,"26,794"
-Pennsylvania,York,8975,York,"449,058"
-Rhode Island,Bristol,1044,Bristol,"48,479"
-Rhode Island,Kent,4152,Kent,"164,292"
-Rhode Island,Newport,1046,Newport,"82,082"
-Rhode Island,Providence,31512,Providence,"638,931"
-Rhode Island,Washington,1891,Washington,"125,577"
-South Carolina,Abbeville,901,Abbeville,"24,527"
-South Carolina,Aiken,5950,Aiken,"170,872"
-South Carolina,Allendale,445,Allendale,"8,688"
-South Carolina,Anderson,7395,Anderson,"202,558"
-South Carolina,Bamberg,717,Bamberg,"14,066"
-South Carolina,Barnwell,942,Barnwell,"20,866"
-South Carolina,Beaufort,6785,Beaufort,"192,122"
-South Carolina,Berkeley,6841,Berkeley,"227,907"
-South Carolina,Calhoun,543,Calhoun,"14,553"
-South Carolina,Charleston,19075,Charleston,"411,406"
-South Carolina,Cherokee,1942,Cherokee,"57,300"
-South Carolina,Chester,1446,Chester,"32,244"
-South Carolina,Chesterfield,1681,Chesterfield,"45,650"
-South Carolina,Clarendon,1313,Clarendon,"33,745"
-South Carolina,Colleton,1440,Colleton,"37,677"
-South Carolina,Darlington,2892,Darlington,"66,618"
-South Carolina,Dillon,1471,Dillon,"30,479"
-South Carolina,Dorchester,5474,Dorchester,"162,809"
-South Carolina,Edgefield,1108,Edgefield,"27,260"
-South Carolina,Fairfield,998,Fairfield,"22,347"
-South Carolina,Florence,6349,Florence,"138,293"
-South Carolina,Georgetown,2664,Georgetown,"62,680"
-South Carolina,Greenville,21843,Greenville,"523,542"
-South Carolina,Greenwood,2911,Greenwood,"70,811"
-South Carolina,Hampton,836,Hampton,"19,222"
-South Carolina,Horry,14051,Horry,"354,081"
-South Carolina,Jasper,1009,Jasper,"30,073"
-South Carolina,Kershaw,2823,Kershaw,"66,551"
-South Carolina,Lancaster,3242,Lancaster,"98,012"
-South Carolina,Laurens,2323,Laurens,"67,493"
-South Carolina,Lee,852,Lee,"16,828"
-South Carolina,Lexington,10736,Lexington,"298,750"
-South Carolina,Marion,1277,McCormick,"9,463"
-South Carolina,Marlboro,1313,Marion,"30,657"
-South Carolina,McCormick,315,Marlboro,"26,118"
-South Carolina,Newberry,2025,Newberry,"38,440"
-South Carolina,Oconee,2969,Oconee,"79,546"
-South Carolina,Orangeburg,3640,Orangeburg,"86,175"
-South Carolina,Pickens,5732,Pickens,"126,884"
-South Carolina,Richland,19441,Richland,"415,759"
-South Carolina,Saluda,777,Saluda,"20,473"
-South Carolina,Spartanburg,11363,Spartanburg,"319,785"
-South Carolina,Sumter,4009,Sumter,"106,721"
-South Carolina,Union,976,Union,"27,316"
-South Carolina,Williamsburg,1588,Williamsburg,"30,368"
-South Carolina,York,8738,York,"280,979"
-South Dakota,Aurora,321,Aurora,"2,751"
-South Dakota,Beadle,2093,Beadle,"18,453"
-South Dakota,Bennett,293,Bennett,"3,365"
-South Dakota,Bon Homme,1288,BonHomme,"6,901"
-South Dakota,Brookings,2204,Brookings,"35,077"
-South Dakota,Brown,3142,Brown,"38,839"
-South Dakota,Brule,512,Brule,"5,297"
-South Dakota,Buffalo,352,Buffalo,"1,962"
-South Dakota,Butte,642,Butte,"10,429"
-South Dakota,Campbell,97,Campbell,"1,376"
-South Dakota,Charles Mix,703,CharlesMix,"9,292"
-South Dakota,Clark,218,Clark,"3,736"
-South Dakota,Clay,1198,Clay,"14,070"
-South Dakota,Codington,2403,Codington,"28,009"
-South Dakota,Corson,336,Corson,"4,086"
-South Dakota,Custer,480,Custer,"8,972"
-South Dakota,Davison,2156,Davison,"19,775"
-South Dakota,Day,297,Day,"5,424"
-South Dakota,Deuel,272,Deuel,"4,351"
-South Dakota,Dewey,720,Dewey,"5,892"
-South Dakota,Douglas,269,Douglas,"2,921"
-South Dakota,Edmunds,221,Edmunds,"3,829"
-South Dakota,Fall River,340,FallRiver,"6,713"
-South Dakota,Faulk,268,Faulk,"2,299"
-South Dakota,Grant,522,Grant,"7,052"
-South Dakota,Gregory,396,Gregory,"4,185"
-South Dakota,Haakon,131,Haakon,"1,899"
-South Dakota,Hamlin,403,Hamlin,"6,164"
-South Dakota,Hand,261,Hand,"3,191"
-South Dakota,Hanson,207,Hanson,"3,453"
-South Dakota,Harding,64,Harding,"1,298"
-South Dakota,Hughes,1483,Hughes,"17,526"
-South Dakota,Hutchinson,483,Hutchinson,"7,291"
-South Dakota,Hyde,109,Hyde,"1,301"
-South Dakota,Jackson,183,Jackson,"3,344"
-South Dakota,Jerauld,227,Jerauld,"2,013"
-South Dakota,Jones,53,Jones,903
-South Dakota,Kingsbury,391,Kingsbury,"4,939"
-South Dakota,Lake,754,Lake,"12,797"
-South Dakota,Lawrence,1779,Lawrence,"25,844"
-South Dakota,Lincoln,4834,Lincoln,"61,128"
-South Dakota,Lyman,412,Lyman,"3,781"
-South Dakota,Marshall,138,McCook,"5,586"
-South Dakota,McCook,546,McPherson,"2,379"
-South Dakota,McPherson,122,Marshall,"4,935"
-South Dakota,Meade,1541,Meade,"28,332"
-South Dakota,Mellette,149,Mellette,"2,061"
-South Dakota,Miner,179,Miner,"2,216"
-South Dakota,Minnehaha,18247,Minnehaha,"193,134"
-South Dakota,Moody,374,Moody,"6,576"
-South Dakota,Oglala Lakota,1498,OglalaLakota,"14,177"
-South Dakota,Pennington,7608,Pennington,"113,775"
-South Dakota,Perkins,139,Perkins,"2,865"
-South Dakota,Potter,233,Potter,"2,153"
-South Dakota,Roberts,624,Roberts,"10,394"
-South Dakota,Sanborn,228,Sanborn,"2,344"
-South Dakota,Spink,504,Spink,"6,376"
-South Dakota,Stanley,207,Stanley,"3,098"
-South Dakota,Sully,82,Sully,"1,391"
-South Dakota,Todd,803,Todd,"10,177"
-South Dakota,Tripp,440,Tripp,"5,441"
-South Dakota,Turner,739,Turner,"8,384"
-South Dakota,Union,1127,Union,"15,932"
-South Dakota,Walworth,420,Walworth,"5,435"
-South Dakota,Yankton,1450,Yankton,"22,814"
-South Dakota,Ziebach,155,Ziebach,"2,756"
-Tennessee,Anderson,2589,Anderson,"76,978"
-Tennessee,Bedford,2412,Bedford,"49,713"
-Tennessee,Benton,718,Benton,"16,160"
-Tennessee,Bledsoe,1133,Bledsoe,"15,064"
-Tennessee,Blount,4900,Blount,"133,088"
-Tennessee,Bradley,4649,Bradley,"108,110"
-Tennessee,Campbell,1389,Campbell,"39,842"
-Tennessee,Cannon,666,Cannon,"14,678"
-Tennessee,Carroll,1565,Carroll,"27,767"
-Tennessee,Carter,2453,Carter,"56,391"
-Tennessee,Cheatham,1432,Cheatham,"40,667"
-Tennessee,Chester,949,Chester,"17,297"
-Tennessee,Claiborne,718,Claiborne,"31,959"
-Tennessee,Clay,519,Clay,"7,615"
-Tennessee,Cocke,1497,Cocke,"36,004"
-Tennessee,Coffee,2547,Coffee,"56,520"
-Tennessee,Crockett,1096,Crockett,"14,230"
-Tennessee,Cumberland,2328,Cumberland,"60,520"
-Tennessee,Davidson,39770,Davidson,"694,144"
-Tennessee,DeKalb,1056,Decatur,"11,663"
-Tennessee,Decatur,885,DeKalb,"20,490"
-Tennessee,Dickson,2597,Dickson,"53,948"
-Tennessee,Dyer,3004,Dyer,"37,159"
-Tennessee,Fayette,2088,Fayette,"41,133"
-Tennessee,Fentress,1133,Fentress,"18,523"
-Tennessee,Franklin,1844,Franklin,"42,208"
-Tennessee,Gibson,2893,Gibson,"49,133"
-Tennessee,Giles,1311,Giles,"29,464"
-Tennessee,Grainger,860,Grainger,"23,320"
-Tennessee,Greene,2715,Greene,"69,069"
-Tennessee,Grundy,720,Grundy,"13,427"
-Tennessee,Hamblen,3163,Hamblen,"64,934"
-Tennessee,Hamilton,15382,Hamilton,"367,804"
-Tennessee,Hancock,138,Hancock,"6,620"
-Tennessee,Hardeman,2175,Hardeman,"25,050"
-Tennessee,Hardin,1680,Hardin,"25,652"
-Tennessee,Hawkins,1727,Hawkins,"56,786"
-Tennessee,Haywood,1553,Haywood,"17,304"
-Tennessee,Henderson,1736,Henderson,"28,117"
-Tennessee,Henry,1352,Henry,"32,345"
-Tennessee,Hickman,1077,Hickman,"25,178"
-Tennessee,Houston,563,Houston,"8,201"
-Tennessee,Humphreys,629,Humphreys,"18,582"
-Tennessee,Jackson,650,Jackson,"11,786"
-Tennessee,Jefferson,2057,Jefferson,"54,495"
-Tennessee,Johnson,1351,Johnson,"17,788"
-Tennessee,Knox,17026,Knox,"470,313"
-Tennessee,Lake,1132,Lake,"7,016"
-Tennessee,Lauderdale,1959,Lauderdale,"25,633"
-Tennessee,Lawrence,2430,Lawrence,"44,142"
-Tennessee,Lewis,690,Lewis,"12,268"
-Tennessee,Lincoln,1358,Lincoln,"34,366"
-Tennessee,Loudon,2084,Loudon,"54,068"
-Tennessee,Macon,1726,McMinn,"53,794"
-Tennessee,Madison,4964,McNairy,"25,694"
-Tennessee,Marion,1014,Macon,"24,602"
-Tennessee,Marshall,1577,Madison,"97,984"
-Tennessee,Maury,5266,Marion,"28,907"
-Tennessee,McMinn,2271,Marshall,"34,375"
-Tennessee,McNairy,1357,Maury,"96,387"
-Tennessee,Meigs,443,Meigs,"12,422"
-Tennessee,Monroe,1916,Monroe,"46,545"
-Tennessee,Montgomery,5956,Montgomery,"208,993"
-Tennessee,Moore,355,Moore,"6,488"
-Tennessee,Morgan,609,Morgan,"21,403"
-Tennessee,Obion,2440,Obion,"30,069"
-Tennessee,Overton,1473,Overton,"22,241"
-Tennessee,Perry,452,Perry,"8,076"
-Tennessee,Pickett,359,Pickett,"5,048"
-Tennessee,Polk,614,Polk,"16,832"
-Tennessee,Putnam,5567,Putnam,"80,245"
-Tennessee,Rhea,1498,Rhea,"33,167"
-Tennessee,Roane,2116,Roane,"53,382"
-Tennessee,Robertson,3415,Robertson,"71,813"
-Tennessee,Rutherford,16264,Rutherford,"332,285"
-Tennessee,Scott,875,Scott,"22,068"
-Tennessee,Sequatchie,484,Sequatchie,"15,026"
-Tennessee,Sevier,4419,Sevier,"98,250"
-Tennessee,Shelby,44615,Shelby,"937,166"
-Tennessee,Smith,1338,Smith,"20,157"
-Tennessee,Stewart,535,Stewart,"13,715"
-Tennessee,Sullivan,5755,Sullivan,"158,348"
-Tennessee,Sumner,8696,Sumner,"191,283"
-Tennessee,Tipton,3294,Tipton,"61,599"
-Tennessee,Trousdale,1885,Trousdale,"11,284"
-Tennessee,Unicoi,728,Unicoi,"17,883"
-Tennessee,Union,669,Union,"19,972"
-Tennessee,Van Buren,317,VanBuren,"5,872"
-Tennessee,Warren,2166,Warren,"41,277"
-Tennessee,Washington,5338,Washington,"129,375"
-Tennessee,Wayne,1764,Wayne,"16,673"
-Tennessee,Weakley,2024,Weakley,"33,328"
-Tennessee,White,1632,White,"27,345"
-Tennessee,Williamson,10231,Williamson,"238,412"
-Tennessee,Wilson,6681,Wilson,"144,657"
-Texas,Anderson,3092,Anderson,"57,735"
-Texas,Andrews,940,Andrews,"18,705"
-Texas,Angelina,2515,Angelina,"86,715"
-Texas,Aransas,376,Aransas,"23,510"
-Texas,Archer,227,Archer,"8,553"
-Texas,Armstrong,39,Armstrong,"1,887"
-Texas,Atascosa,1418,Atascosa,"51,153"
-Texas,Austin,554,Austin,"30,032"
-Texas,Bailey,439,Bailey,"7,000"
-Texas,Bandera,219,Bandera,"23,112"
-Texas,Bastrop,2198,Bastrop,"88,723"
-Texas,Baylor,52,Baylor,"3,509"
-Texas,Bee,1943,Bee,"32,565"
-Texas,Bell,7911,Bell,"362,924"
-Texas,Bexar,72313,Bexar,"2,003,554"
-Texas,Blanco,176,Blanco,"11,931"
-Texas,Borden,4,Borden,654
-Texas,Bosque,507,Bosque,"18,685"
-Texas,Bowie,2406,Bowie,"93,245"
-Texas,Brazoria,13626,Brazoria,"374,264"
-Texas,Brazos,8944,Brazos,"229,211"
-Texas,Brewster,427,Brewster,"9,203"
-Texas,Briscoe,39,Briscoe,"1,546"
-Texas,Brooks,388,Brooks,"7,093"
-Texas,Brown,875,Brown,"37,864"
-Texas,Burleson,617,Burleson,"18,443"
-Texas,Burnet,1303,Burnet,"48,155"
-Texas,Caldwell,1813,Caldwell,"43,664"
-Texas,Calhoun,968,Calhoun,"21,290"
-Texas,Callahan,196,Callahan,"13,943"
-Texas,Cameron,25396,Cameron,"423,163"
-Texas,Camp,441,Camp,"13,094"
-Texas,Carson,86,Carson,"5,926"
-Texas,Cass,716,Cass,"30,026"
-Texas,Castro,427,Castro,"7,530"
-Texas,Chambers,1845,Chambers,"43,837"
-Texas,Cherokee,1717,Cherokee,"52,646"
-Texas,Childress,810,Childress,"7,306"
-Texas,Clay,239,Clay,"10,471"
-Texas,Cochran,148,Cochran,"2,853"
-Texas,Coke,161,Coke,"3,387"
-Texas,Coleman,172,Coleman,"8,175"
-Texas,Collin,22369,Collin,"1,034,730"
-Texas,Collingsworth,38,Collingsworth,"2,920"
-Texas,Colorado,559,Colorado,"21,493"
-Texas,Comal,3079,Comal,"156,209"
-Texas,Comanche,416,Comanche,"13,635"
-Texas,Concho,180,Concho,"2,726"
-Texas,Cooke,713,Cooke,"41,257"
-Texas,Coryell,2281,Coryell,"75,951"
-Texas,Cottle,52,Cottle,"1,398"
-Texas,Crane,159,Crane,"4,797"
-Texas,Crockett,210,Crockett,"3,464"
-Texas,Crosby,163,Crosby,"5,737"
-Texas,Culberson,175,Culberson,"2,171"
-Texas,Dallam,426,Dallam,"7,287"
-Texas,Dallas,115410,Dallas,"2,635,516"
-Texas,Dawson,1141,Dawson,"12,728"
-Texas,DeWitt,1167,DeafSmith,"18,546"
-Texas,Deaf Smith,1219,Delta,"5,331"
-Texas,Delta,46,Denton,"887,207"
-Texas,Denton,18141,DeWitt,"20,160"
-Texas,Dickens,64,Dickens,"2,211"
-Texas,Dimmit,341,Dimmit,"10,124"
-Texas,Donley,107,Donley,"3,278"
-Texas,Duval,561,Duval,"11,157"
-Texas,Eastland,336,Eastland,"18,360"
-Texas,Ector,8206,Ector,"166,223"
-Texas,Edwards,81,Edwards,"1,932"
-Texas,El Paso,79162,Ellis,"184,826"
-Texas,Ellis,6070,ElPaso,"839,238"
-Texas,Erath,1243,Erath,"42,698"
-Texas,Falls,748,Falls,"17,297"
-Texas,Fannin,930,Fannin,"35,514"
-Texas,Fayette,751,Fayette,"25,346"
-Texas,Fisher,145,Fisher,"3,830"
-Texas,Floyd,179,Floyd,"5,712"
-Texas,Foard,25,Foard,"1,155"
-Texas,Fort Bend,19223,FortBend,"811,688"
-Texas,Franklin,245,Franklin,"10,725"
-Texas,Freestone,493,Freestone,"19,717"
-Texas,Frio,1082,Frio,"20,306"
-Texas,Gaines,856,Gaines,"21,492"
-Texas,Galveston,13922,Galveston,"342,139"
-Texas,Garza,159,Garza,"6,229"
-Texas,Gillespie,439,Gillespie,"26,988"
-Texas,Glasscock,30,Glasscock,"1,409"
-Texas,Goliad,177,Goliad,"7,658"
-Texas,Gonzales,1205,Gonzales,"20,837"
-Texas,Gray,1196,Gray,"21,886"
-Texas,Grayson,3818,Grayson,"136,212"
-Texas,Gregg,3070,Gregg,"123,945"
-Texas,Grimes,1314,Grimes,"28,880"
-Texas,Guadalupe,4131,Guadalupe,"166,847"
-Texas,Hale,3742,Hale,"33,406"
-Texas,Hall,76,Hall,"2,964"
-Texas,Hamilton,275,Hamilton,"8,461"
-Texas,Hansford,226,Hansford,"5,399"
-Texas,Hardeman,77,Hardeman,"3,933"
-Texas,Hardin,1560,Hardin,"57,602"
-Texas,Harris,179911,Harris,"4,713,325"
-Texas,Harrison,1215,Harrison,"66,553"
-Texas,Hartley,200,Hartley,"5,576"
-Texas,Haskell,94,Haskell,"5,658"
-Texas,Hays,6960,Hays,"230,191"
-Texas,Hemphill,232,Hemphill,"3,819"
-Texas,Henderson,1682,Henderson,"82,737"
-Texas,Hidalgo,40085,Hidalgo,"868,707"
-Texas,Hill,1101,Hill,"36,649"
-Texas,Hockley,1203,Hockley,"23,021"
-Texas,Hood,1455,Hood,"61,643"
-Texas,Hopkins,790,Hopkins,"37,084"
-Texas,Houston,506,Houston,"22,968"
-Texas,Howard,1619,Howard,"36,664"
-Texas,Hudspeth,164,Hudspeth,"4,886"
-Texas,Hunt,2528,Hunt,"98,594"
-Texas,Hutchinson,594,Hutchinson,"20,938"
-Texas,Irion,16,Irion,"1,536"
-Texas,Jack,214,Jack,"8,935"
-Texas,Jackson,762,Jackson,"14,760"
-Texas,Jasper,537,Jasper,"35,529"
-Texas,Jeff Davis,43,JeffDavis,"2,274"
-Texas,Jefferson,9728,Jefferson,"251,565"
-Texas,Jim Hogg,206,JimHogg,"5,200"
-Texas,Jim Wells,1894,JimWells,"40,482"
-Texas,Johnson,4788,Johnson,"175,817"
-Texas,Jones,1593,Jones,"20,083"
-Texas,Karnes,986,Karnes,"15,601"
-Texas,Kaufman,4286,Kaufman,"136,154"
-Texas,Kendall,476,Kendall,"47,431"
-Texas,Kenedy,11,Kenedy,404
-Texas,Kent,21,Kent,762
-Texas,Kerr,848,Kerr,"52,600"
-Texas,Kimble,79,Kimble,"4,337"
-Texas,King,1,King,272
-Texas,Kinney,85,Kinney,"3,667"
-Texas,Kleberg,1129,Kleberg,"30,680"
-Texas,Knox,117,Knox,"3,664"
-Texas,La Salle,388,Lamar,"49,859"
-Texas,Lamar,2385,Lamb,"12,893"
-Texas,Lamb,876,Lampasas,"21,428"
-Texas,Lampasas,356,LaSalle,"7,520"
-Texas,Lavaca,1332,Lavaca,"20,154"
-Texas,Lee,273,Lee,"17,239"
-Texas,Leon,425,Leon,"17,404"
-Texas,Liberty,2399,Liberty,"88,219"
-Texas,Limestone,752,Limestone,"23,437"
-Texas,Lipscomb,117,Lipscomb,"3,233"
-Texas,Live Oak,418,LiveOak,"12,207"
-Texas,Llano,259,Llano,"21,795"
-Texas,Loving,1,Loving,169
-Texas,Lubbock,27660,Lubbock,"310,569"
-Texas,Lynn,301,Lynn,"5,951"
-Texas,Madison,854,McCulloch,"7,984"
-Texas,Marion,182,McLennan,"256,623"
-Texas,Martin,170,McMullen,743
-Texas,Mason,133,Madison,"14,284"
-Texas,Matagorda,1199,Marion,"9,854"
-Texas,Maverick,4722,Martin,"5,771"
-Texas,McCulloch,274,Mason,"4,274"
-Texas,McLennan,12947,Matagorda,"36,643"
-Texas,McMullen,27,Maverick,"58,722"
-Texas,Medina,1359,Medina,"51,584"
-Texas,Menard,103,Menard,"2,138"
-Texas,Midland,6576,Midland,"176,832"
-Texas,Milam,609,Milam,"24,823"
-Texas,Mills,128,Mills,"4,873"
-Texas,Mitchell,280,Mitchell,"8,545"
-Texas,Montague,502,Montague,"19,818"
-Texas,Montgomery,15920,Montgomery,"607,391"
-Texas,Moore,1537,Moore,"20,940"
-Texas,Morris,261,Morris,"12,388"
-Texas,Motley,19,Motley,"1,200"
-Texas,Nacogdoches,1915,Nacogdoches,"65,204"
-Texas,Navarro,1696,Navarro,"50,113"
-Texas,Newton,195,Newton,"13,595"
-Texas,Nolan,633,Nolan,"14,714"
-Texas,Nueces,22942,Nueces,"362,294"
-Texas,Ochiltree,487,Ochiltree,"9,836"
-Texas,Oldham,33,Oldham,"2,112"
-Texas,Orange,2491,Orange,"83,396"
-Texas,Palo Pinto,882,PaloPinto,"29,189"
-Texas,Panola,522,Panola,"23,194"
-Texas,Parker,3365,Parker,"142,878"
-Texas,Parmer,669,Parmer,"9,605"
-Texas,Pecos,687,Pecos,"15,823"
-Texas,Polk,991,Polk,"51,353"
-Texas,Potter,11521,Potter,"117,415"
-Texas,Presidio,270,Presidio,"6,704"
-Texas,Rains,152,Rains,"12,514"
-Texas,Randall,9040,Randall,"137,713"
-Texas,Reagan,159,Reagan,"3,849"
-Texas,Real,130,Real,"3,452"
-Texas,Red River,216,RedRiver,"12,023"
-Texas,Reeves,466,Reeves,"15,976"
-Texas,Refugio,333,Refugio,"6,948"
-Texas,Roberts,24,Roberts,854
-Texas,Robertson,469,Robertson,"17,074"
-Texas,Rockwall,2511,Rockwall,"104,915"
-Texas,Runnels,332,Runnels,"10,264"
-Texas,Rusk,1161,Rusk,"54,406"
-Texas,Sabine,120,Sabine,"10,542"
-Texas,San Augustine,256,SanAugustine,"8,237"
-Texas,San Jacinto,250,SanJacinto,"28,859"
-Texas,San Patricio,1747,SanPatricio,"66,730"
-Texas,San Saba,294,SanSaba,"6,055"
-Texas,Schleicher,105,Schleicher,"2,793"
-Texas,Scurry,1449,Scurry,"16,703"
-Texas,Shackelford,46,Shackelford,"3,265"
-Texas,Shelby,589,Shelby,"25,274"
-Texas,Sherman,86,Sherman,"3,022"
-Texas,Smith,5604,Smith,"232,751"
-Texas,Somervell,225,Somervell,"9,128"
-Texas,Starr,3784,Starr,"64,633"
-Texas,Stephens,225,Stephens,"9,366"
-Texas,Sterling,33,Sterling,"1,291"
-Texas,Stonewall,24,Stonewall,"1,350"
-Texas,Sutton,179,Sutton,"3,776"
-Texas,Swisher,227,Swisher,"7,397"
-Texas,Tarrant,88948,Tarrant,"2,102,515"
-Texas,Taylor,3015,Taylor,"138,034"
-Texas,Terrell,13,Terrell,776
-Texas,Terry,882,Terry,"12,337"
-Texas,Throckmorton,23,Throckmorton,"1,501"
-Texas,Titus,1831,Titus,"32,750"
-Texas,Tom Green,7954,TomGreen,"119,200"
-Texas,Travis,35984,Travis,"1,273,954"
-Texas,Trinity,225,Trinity,"14,651"
-Texas,Tyler,295,Tyler,"21,672"
-Texas,Upshur,587,Upshur,"41,753"
-Texas,Upton,42,Upton,"3,657"
-Texas,Uvalde,1029,Uvalde,"26,741"
-Texas,Val Verde,2932,ValVerde,"49,025"
-Texas,Van Zandt,1017,VanZandt,"56,590"
-Texas,Victoria,4761,Victoria,"92,084"
-Texas,Walker,4076,Walker,"72,971"
-Texas,Waller,1077,Waller,"55,246"
-Texas,Ward,310,Ward,"11,998"
-Texas,Washington,907,Washington,"35,882"
-Texas,Webb,18109,Webb,"276,652"
-Texas,Wharton,1554,Wharton,"41,556"
-Texas,Wheeler,203,Wheeler,"5,056"
-Texas,Wichita,6023,Wichita,"132,230"
-Texas,Wilbarger,575,Wilbarger,"12,769"
-Texas,Willacy,1314,Willacy,"21,358"
-Texas,Williamson,11559,Williamson,"590,551"
-Texas,Wilson,1079,Wilson,"51,070"
-Texas,Winkler,257,Winkler,"8,010"
-Texas,Wise,1402,Wise,"69,984"
-Texas,Wood,846,Wood,"45,539"
-Texas,Yoakum,568,Yoakum,"8,713"
-Texas,Young,790,Young,"18,010"
-Texas,Zapata,427,Zapata,"14,179"
-Texas,Zavala,551,Zavala,"11,840"
-Utah,Beaver,0,Beaver,"6,710"
-Utah,Box Elder,8634,BoxElder,"56,046"
-Utah,Cache,0,Cache,"128,289"
-Utah,Carbon,0,Carbon,"20,463"
-Utah,Daggett,0,Daggett,950
-Utah,Davis,14114,Davis,"355,481"
-Utah,Duchesne,0,Duchesne,"19,938"
-Utah,Emery,0,Emery,"10,012"
-Utah,Garfield,0,Garfield,"5,051"
-Utah,Grand,0,Grand,"9,754"
-Utah,Iron,0,Iron,"54,839"
-Utah,Juab,0,Juab,"12,017"
-Utah,Kane,0,Kane,"7,886"
-Utah,Millard,0,Millard,"13,188"
-Utah,Morgan,0,Morgan,"12,124"
-Utah,Piute,0,Piute,"1,479"
-Utah,Rich,0,Rich,"2,483"
-Utah,Salt Lake,71088,SaltLake,"1,160,437"
-Utah,San Juan,970,SanJuan,"15,308"
-Utah,Sanpete,0,Sanpete,"30,939"
-Utah,Sevier,0,Sevier,"21,620"
-Utah,Summit,2018,Summit,"42,145"
-Utah,Tooele,2516,Tooele,"72,259"
-Utah,Uintah,1195,Uintah,"35,734"
-Utah,Utah,43201,Utah,"636,235"
-Utah,Wasatch,1808,Wasatch,"34,091"
-Utah,Washington,13690,Washington,"177,556"
-Utah,Wayne,0,Wayne,"2,711"
-Utah,Weber,11350,Weber,"260,213"
-Vermont,Addison,157,Addison,"36,777"
-Vermont,Bennington,181,Bennington,"35,470"
-Vermont,Caledonia,92,Caledonia,"29,993"
-Vermont,Chittenden,1330,Chittenden,"163,774"
-Vermont,Essex,26,Essex,"6,163"
-Vermont,Franklin,187,Franklin,"49,402"
-Vermont,Grand Isle,36,GrandIsle,"7,235"
-Vermont,Lamoille,125,Lamoille,"25,362"
-Vermont,Orange,159,Orange,"28,892"
-Vermont,Orleans,99,Orleans,"27,037"
-Vermont,Rutland,205,Rutland,"58,191"
-Vermont,Washington,501,Washington,"58,409"
-Vermont,Windham,190,Windham,"42,222"
-Vermont,Windsor,163,Windsor,"55,062"
-Virginia,Accomack,1282,Accomack,"32,316"
-Virginia,Albemarle,1767,Albemarle,"109,330"
-Virginia,Alexandria,4831,AlexandriacityVirginia,"159,428"
-Virginia,Alleghany,262,Alleghany,"14,860"
-Virginia,Amelia,170,Amelia,"13,145"
-Virginia,Amherst,710,Amherst,"31,605"
-Virginia,Appomattox,371,Appomattox,"15,911"
-Virginia,Arlington,5603,Arlington,"236,842"
-Virginia,Augusta,985,Augusta,"75,558"
-Virginia,Bath,48,Bath,"4,147"
-Virginia,Bedford,1660,Bedford,"78,997"
-Virginia,Bland,113,Bland,"6,280"
-Virginia,Botetourt,676,Botetourt,"33,419"
-Virginia,Bristol,473,BristolcityVirginia,"16,762"
-Virginia,Brunswick,454,Brunswick,"16,231"
-Virginia,Buchanan,359,Buchanan,"21,004"
-Virginia,Buckingham,838,Buckingham,"17,148"
-Virginia,Buena Vista,209,BuenaVistacityVirginia,"6,478"
-Virginia,Campbell,1006,Campbell,"54,885"
-Virginia,Caroline,531,Caroline,"30,725"
-Virginia,Carroll,822,Carroll,"29,791"
-Virginia,Charles City,127,CharlesCity,"6,963"
-Virginia,Charlotte,266,Charlotte,"11,880"
-Virginia,Charlottesville,1777,CharlottesvillecityVirginia,"47,266"
-Virginia,Chesapeake,5799,ChesapeakecityVirginia,"244,835"
-Virginia,Chesterfield,8451,Chesterfield,"352,802"
-Virginia,Clarke,178,Clarke,"14,619"
-Virginia,Colonial Heights,369,ColonialHeightscityVirginia,"17,370"
-Virginia,Covington,112,CovingtoncityVirginia,"5,538"
-Virginia,Craig,79,Craig,"5,131"
-Virginia,Culpeper,1866,Culpeper,"52,605"
-Virginia,Cumberland,141,Cumberland,"9,932"
-Virginia,Danville,1492,DanvillecityVirginia,"40,044"
-Virginia,Dickenson,233,Dickenson,"14,318"
-Virginia,Dinwiddie,618,Dinwiddie,"28,544"
-Virginia,Emporia,309,EmporiacityVirginia,"5,346"
-Virginia,Essex,223,Essex,"10,953"
-Virginia,Fairfax,27732,Fairfax,"1,147,532"
-Virginia,Fairfax City,193,FairfaxcityVirginia,"24,019"
-Virginia,Falls Church,88,FallsChurchcityVirginia,"14,617"
-Virginia,Fauquier,1332,Fauquier,"71,222"
-Virginia,Floyd,303,Floyd,"15,749"
-Virginia,Fluvanna,471,Fluvanna,"27,270"
-Virginia,Franklin,1374,Franklin,"56,042"
-Virginia,Franklin City,533,FranklincityVirginia,"7,967"
-Virginia,Frederick,1741,Frederick,"89,313"
-Virginia,Fredericksburg,643,FredericksburgcityVirginia,"29,036"
-Virginia,Galax,518,GalaxcityVirginia,"6,347"
-Virginia,Giles,223,Giles,"16,720"
-Virginia,Gloucester,391,Gloucester,"37,348"
-Virginia,Goochland,389,Goochland,"23,753"
-Virginia,Grayson,477,Grayson,"15,550"
-Virginia,Greene,340,Greene,"19,819"
-Virginia,Greensville,925,Greensville,"11,336"
-Virginia,Halifax,758,Halifax,"33,911"
-Virginia,Hampton,2506,HamptoncityVirginia,"134,510"
-Virginia,Hanover,2139,Hanover,"107,766"
-Virginia,Harrisonburg,3319,HarrisonburgcityVirginia,"53,016"
-Virginia,Henrico,7604,Henrico,"330,818"
-Virginia,Henry,1688,Henry,"50,557"
-Virginia,Highland,14,Highland,"2,190"
-Virginia,Hopewell,576,HopewellcityVirginia,"22,529"
-Virginia,Isle of Wight,957,IsleofWight,"37,109"
-Virginia,James City,1090,JamesCity,"76,523"
-Virginia,King George,354,KingandQueen,"7,025"
-Virginia,King William,263,KingGeorge,"26,836"
-Virginia,King and Queen,100,KingWilliam,"17,148"
-Virginia,Lancaster,224,Lancaster,"10,603"
-Virginia,Lee,783,Lee,"23,423"
-Virginia,Lexington,315,LexingtoncityVirginia,"7,446"
-Virginia,Loudoun,9149,Loudoun,"413,538"
-Virginia,Louisa,464,Louisa,"37,591"
-Virginia,Lunenburg,163,Lunenburg,"12,196"
-Virginia,Lynchburg,2446,LynchburgcityVirginia,"82,168"
-Virginia,Madison,171,Madison,"13,261"
-Virginia,Manassas,2183,ManassascityVirginia,"41,085"
-Virginia,Manassas Park,689,ManassasParkcityVirginia,"17,478"
-Virginia,Martinsville,608,MartinsvillecityVirginia,"12,554"
-Virginia,Mathews,151,Mathews,"8,834"
-Virginia,Mecklenburg,962,Mecklenburg,"30,587"
-Virginia,Middlesex,152,Middlesex,"10,582"
-Virginia,Montgomery,3581,Montgomery,"98,535"
-Virginia,Nelson,159,Nelson,"14,930"
-Virginia,New Kent,351,NewKent,"23,091"
-Virginia,Newport News,3688,NewportNewscityVirginia,"179,225"
-Virginia,Norfolk,6144,NorfolkcityVirginia,"242,742"
-Virginia,Northampton,335,Northampton,"11,710"
-Virginia,Northumberland,246,Northumberland,"12,095"
-Virginia,Norton,65,NortoncityVirginia,"3,981"
-Virginia,Nottoway,475,Nottoway,"15,232"
-Virginia,Orange,515,Orange,"37,051"
-Virginia,Page,549,Page,"23,902"
-Virginia,Patrick,415,Patrick,"17,608"
-Virginia,Petersburg,1031,PetersburgcityVirginia,"31,346"
-Virginia,Pittsylvania,1565,Pittsylvania,"60,354"
-Virginia,Poquoson,122,PoquosoncityVirginia,"12,271"
-Virginia,Portsmouth,3053,PortsmouthcityVirginia,"94,398"
-Virginia,Powhatan,391,Powhatan,"29,652"
-Virginia,Prince Edward,841,PrinceEdward,"22,802"
-Virginia,Prince George,1348,PrinceGeorge,"38,353"
-Virginia,Prince William,16595,PrinceWilliam,"470,335"
-Virginia,Pulaski,505,Pulaski,"34,027"
-Virginia,Radford,1085,RadfordcityVirginia,"18,249"
-Virginia,Rappahannock,75,Rappahannock,"7,370"
-Virginia,Richmond,380,Richmond,"9,023"
-Virginia,Richmond City,6215,RichmondcityVirginia,"230,436"
-Virginia,Roanoke,2460,Roanoke,"94,186"
-Virginia,Roanoke City,3772,RoanokecityVirginia,"99,143"
-Virginia,Rockbridge,214,Rockbridge,"22,573"
-Virginia,Rockingham,2063,Rockingham,"81,948"
-Virginia,Russell,733,Russell,"26,586"
-Virginia,Salem,791,SalemcityVirginia,"25,301"
-Virginia,Scott,672,Scott,"21,566"
-Virginia,Shenandoah,1268,Shenandoah,"43,616"
-Virginia,Smyth,898,Smyth,"30,104"
-Virginia,Southampton,962,Southampton,"17,631"
-Virginia,Spotsylvania,2860,Spotsylvania,"136,215"
-Virginia,Stafford,2922,Stafford,"152,882"
-Virginia,Staunton,548,StauntoncityVirginia,"24,932"
-Virginia,Suffolk,2582,SuffolkcityVirginia,"92,108"
-Virginia,Surry,154,Surry,"6,422"
-Virginia,Sussex,658,Sussex,"11,159"
-Virginia,Tazewell,878,Tazewell,"40,595"
-Virginia,Virginia Beach,9716,VirginiaBeachcityVirginia,"449,974"
-Virginia,Warren,746,Warren,"40,164"
-Virginia,Washington,1544,Washington,"53,740"
-Virginia,Waynesboro,502,WaynesborocityVirginia,"22,630"
-Virginia,Westmoreland,393,Westmoreland,"18,015"
-Virginia,Williamsburg,275,WilliamsburgcityVirginia,"14,954"
-Virginia,Winchester,847,WinchestercityVirginia,"28,078"
-Virginia,Wise,1097,Wise,"37,383"
-Virginia,Wythe,530,Wythe,"28,684"
-Virginia,York,806,York,"68,280"
-Washington,Adams,1232,Adams,"19,983"
-Washington,Asotin,535,Asotin,"22,582"
-Washington,Benton,6996,Benton,"204,390"
-Washington,Chelan,2201,Chelan,"77,200"
-Washington,Clallam,362,Clallam,"77,331"
-Washington,Clark,7093,Clark,"488,241"
-Washington,Columbia,27,Columbia,"3,985"
-Washington,Cowlitz,1132,Cowlitz,"110,593"
-Washington,Douglas,1290,Douglas,"43,429"
-Washington,Ferry,48,Ferry,"7,627"
-Washington,Franklin,5753,Franklin,"95,222"
-Washington,Garfield,52,Garfield,"2,225"
-Washington,Grant,3754,Grant,"97,733"
-Washington,Grays Harbor,904,GraysHarbor,"75,061"
-Washington,Island,536,Island,"85,141"
-Washington,Jefferson,134,Jefferson,"32,221"
-Washington,King,37113,King,"2,252,782"
-Washington,Kitsap,2100,Kitsap,"271,473"
-Washington,Kittitas,851,Kittitas,"47,935"
-Washington,Klickitat,239,Klickitat,"22,425"
-Washington,Lewis,997,Lewis,"80,707"
-Washington,Lincoln,127,Lincoln,"10,939"
-Washington,Mason,649,Mason,"66,768"
-Washington,Okanogan,1174,Okanogan,"42,243"
-Washington,Pacific,190,Pacific,"22,471"
-Washington,Pend Oreille,190,PendOreille,"13,724"
-Washington,Pierce,14093,Pierce,"904,980"
-Washington,San Juan,55,SanJuan,"17,582"
-Washington,Skagit,1711,Skagit,"129,205"
-Washington,Skamania,87,Skamania,"12,083"
-Washington,Snohomish,12173,Snohomish,"822,083"
-Washington,Spokane,13523,Spokane,"522,798"
-Washington,Stevens,479,Stevens,"45,723"
-Washington,Thurston,2494,Thurston,"290,536"
-Washington,Wahkiakum,14,Wahkiakum,"4,488"
-Washington,Walla Walla,1865,WallaWalla,"60,760"
-Washington,Whatcom,2002,Whatcom,"229,247"
-Washington,Whitman,2150,Whitman,"50,104"
-Washington,Yakima,12747,Yakima,"250,873"
-West Virginia,Barbour,312,Barbour,"16,441"
-West Virginia,Berkeley,2544,Berkeley,"119,171"
-West Virginia,Boone,559,Boone,"21,457"
-West Virginia,Braxton,99,Braxton,"13,957"
-West Virginia,Brooke,483,Brooke,"21,939"
-West Virginia,Cabell,2421,Cabell,"91,945"
-West Virginia,Calhoun,53,Calhoun,"7,109"
-West Virginia,Clay,104,Clay,"8,508"
-West Virginia,Doddridge,98,Doddridge,"8,448"
-West Virginia,Fayette,1023,Fayette,"42,406"
-West Virginia,Gilmer,180,Gilmer,"7,823"
-West Virginia,Grant,267,Grant,"11,568"
-West Virginia,Greenbrier,361,Greenbrier,"34,662"
-West Virginia,Hampshire,246,Hampshire,"23,175"
-West Virginia,Hancock,474,Hancock,"28,810"
-West Virginia,Hardy,181,Hardy,"13,776"
-West Virginia,Harrison,1019,Harrison,"67,256"
-West Virginia,Jackson,636,Jackson,"28,576"
-West Virginia,Jefferson,1093,Jefferson,"57,146"
-West Virginia,Kanawha,5024,Kanawha,"178,124"
-West Virginia,Lewis,219,Lewis,"15,907"
-West Virginia,Lincoln,375,Lincoln,"20,409"
-West Virginia,Logan,965,Logan,"32,019"
-West Virginia,Marion,667,McDowell,"17,624"
-West Virginia,Marshall,961,Marion,"56,072"
-West Virginia,Mason,309,Marshall,"30,531"
-West Virginia,McDowell,557,Mason,"26,516"
-West Virginia,Mercer,1163,Mercer,"58,758"
-West Virginia,Mineral,798,Mineral,"26,868"
-West Virginia,Mingo,889,Mingo,"23,424"
-West Virginia,Monongalia,2948,Monongalia,"105,612"
-West Virginia,Monroe,321,Monroe,"13,275"
-West Virginia,Morgan,226,Morgan,"17,884"
-West Virginia,Nicholas,291,Nicholas,"24,496"
-West Virginia,Ohio,1219,Ohio,"41,411"
-West Virginia,Pendleton,90,Pendleton,"6,969"
-West Virginia,Pleasants,66,Pleasants,"7,460"
-West Virginia,Pocahontas,89,Pocahontas,"8,247"
-West Virginia,Preston,420,Preston,"33,432"
-West Virginia,Putnam,1550,Putnam,"56,450"
-West Virginia,Raleigh,1333,Raleigh,"73,361"
-West Virginia,Randolph,599,Randolph,"28,695"
-West Virginia,Ritchie,107,Ritchie,"9,554"
-West Virginia,Roane,144,Roane,"13,688"
-West Virginia,Summers,242,Summers,"12,573"
-West Virginia,Taylor,246,Taylor,"16,695"
-West Virginia,Tucker,98,Tucker,"6,839"
-West Virginia,Tyler,116,Tyler,"8,591"
-West Virginia,Upshur,410,Upshur,"24,176"
-West Virginia,Wayne,871,Wayne,"39,402"
-West Virginia,Webster,51,Webster,"8,114"
-West Virginia,Wetzel,352,Wetzel,"15,065"
-West Virginia,Wirt,77,Wirt,"5,821"
-West Virginia,Wood,1950,Wood,"83,518"
-West Virginia,Wyoming,584,Wyoming,"20,394"
-Wisconsin,Adams,1006,Adams,"20,220"
-Wisconsin,Ashland,584,Ashland,"15,562"
-Wisconsin,Barron,3186,Barron,"45,244"
-Wisconsin,Bayfield,613,Bayfield,"15,036"
-Wisconsin,Brown,21354,Brown,"264,542"
-Wisconsin,Buffalo,691,Buffalo,"13,031"
-Wisconsin,Burnett,689,Burnett,"15,414"
-Wisconsin,Calumet,3942,Calumet,"50,089"
-Wisconsin,Chippewa,4009,Chippewa,"64,658"
-Wisconsin,Clark,2015,Clark,"34,774"
-Wisconsin,Columbia,3194,Columbia,"57,532"
-Wisconsin,Crawford,797,Crawford,"16,131"
-Wisconsin,Dane,24973,Dane,"546,695"
-Wisconsin,Dodge,7813,Dodge,"87,839"
-Wisconsin,Door,1593,Door,"27,668"
-Wisconsin,Douglas,1628,Douglas,"43,150"
-Wisconsin,Dunn,2365,Dunn,"45,368"
-Wisconsin,Eau Claire,7018,EauClaire,"104,646"
-Wisconsin,Florence,309,Florence,"4,295"
-Wisconsin,Fond du Lac,8097,FondduLac,"103,403"
-Wisconsin,Forest,725,Forest,"9,004"
-Wisconsin,Grant,3310,Grant,"51,439"
-Wisconsin,Green,1522,Green,"36,960"
-Wisconsin,Green Lake,1310,GreenLake,"18,913"
-Wisconsin,Iowa,1175,Iowa,"23,678"
-Wisconsin,Iron,380,Iron,"5,687"
-Wisconsin,Jackson,1447,Jackson,"20,643"
-Wisconsin,Jefferson,5013,Jefferson,"84,769"
-Wisconsin,Juneau,1721,Juneau,"26,687"
-Wisconsin,Kenosha,9140,Kenosha,"169,561"
-Wisconsin,Kewaunee,1569,Kewaunee,"20,434"
-Wisconsin,La Crosse,7340,LaCrosse,"118,016"
-Wisconsin,Lafayette,1017,Lafayette,"16,665"
-Wisconsin,Langlade,1497,Langlade,"19,189"
-Wisconsin,Lincoln,1776,Lincoln,"27,593"
-Wisconsin,Manitowoc,4967,Manitowoc,"78,981"
-Wisconsin,Marathon,9406,Marathon,"135,692"
-Wisconsin,Marinette,2889,Marinette,"40,350"
-Wisconsin,Marquette,1092,Marquette,"15,574"
-Wisconsin,Menominee,533,Menominee,"4,556"
-Wisconsin,Milwaukee,64259,Milwaukee,"945,726"
-Wisconsin,Monroe,2217,Monroe,"46,253"
-Wisconsin,Oconto,3146,Oconto,"37,930"
-Wisconsin,Oneida,2138,Oneida,"35,595"
-Wisconsin,Outagamie,13475,Outagamie,"187,885"
-Wisconsin,Ozaukee,4693,Ozaukee,"89,221"
-Wisconsin,Pepin,418,Pepin,"7,287"
-Wisconsin,Pierce,2106,Pierce,"42,754"
-Wisconsin,Polk,1799,Polk,"43,783"
-Wisconsin,Portage,4429,Portage,"70,772"
-Wisconsin,Price,668,Price,"13,351"
-Wisconsin,Racine,13838,Racine,"196,311"
-Wisconsin,Richland,785,Richland,"17,252"
-Wisconsin,Rock,8554,Rock,"163,354"
-Wisconsin,Rusk,723,Rusk,"14,178"
-Wisconsin,Sauk,3252,StCroix,"90,687"
-Wisconsin,Sawyer,760,Sauk,"64,442"
-Wisconsin,Shawano,3608,Sawyer,"16,558"
-Wisconsin,Sheboygan,8447,Shawano,"40,899"
-Wisconsin,St. Croix,3990,Sheboygan,"115,340"
-Wisconsin,Taylor,1095,Taylor,"20,343"
-Wisconsin,Trempealeau,2091,Trempealeau,"29,649"
-Wisconsin,Vernon,945,Vernon,"30,822"
-Wisconsin,Vilas,1100,Vilas,"22,195"
-Wisconsin,Walworth,6105,Walworth,"103,868"
-Wisconsin,Washburn,572,Washburn,"15,720"
-Wisconsin,Washington,8504,Washington,"136,034"
-Wisconsin,Waukesha,25013,Waukesha,"404,198"
-Wisconsin,Waupaca,3871,Waupaca,"50,990"
-Wisconsin,Waushara,1713,Waushara,"24,443"
-Wisconsin,Winnebago,13287,Winnebago,"171,907"
-Wisconsin,Wood,3884,Wood,"72,999"
-Wyoming,Albany,2817,Albany,"38,880"
-Wyoming,Big Horn,418,BigHorn,"11,790"
-Wyoming,Campbell,2470,Campbell,"46,341"
-Wyoming,Carbon,556,Carbon,"14,800"
-Wyoming,Converse,535,Converse,"13,822"
-Wyoming,Crook,272,Crook,"7,584"
-Wyoming,Fremont,2827,Fremont,"39,261"
-Wyoming,Goshen,505,Goshen,"13,211"
-Wyoming,Hot Springs,117,HotSprings,"4,413"
-Wyoming,Johnson,251,Johnson,"8,445"
-Wyoming,Laramie,4006,Laramie,"99,500"
-Wyoming,Lincoln,567,Lincoln,"19,830"
-Wyoming,Natrona,4082,Natrona,"79,858"
-Wyoming,Niobrara,88,Niobrara,"2,356"
-Wyoming,Park,1158,Park,"29,194"
-Wyoming,Platte,282,Platte,"8,393"
-Wyoming,Sheridan,1592,Sheridan,"30,485"
-Wyoming,Sublette,349,Sublette,"9,831"
-Wyoming,Sweetwater,1353,Sweetwater,"42,343"
-Wyoming,Teton,1336,Teton,"23,464"
-Wyoming,Uinta,894,Uinta,"20,226"
-Wyoming,Washakie,290,Washakie,"7,805"
-Wyoming,Weston,364,Weston,"6,927"
+State,County,Cases,County,Population,
+Alabama,Shelby,9537,St. Clair,"89,512",FALSE
+Alabama,St. Clair,3891,Shelby,"217,702",FALSE
+Alaska,Matanuska-Susitna,2504,LakeandPeninsulaBoroughAlaska,"1,592",FALSE
+Alaska,Nome,178,Matanuska-Susitna,"108,317",FALSE
+Alaska,North Slope,403,Nome,"10,004",FALSE
+Alaska,Northwest Arctic,326,North Slope,"9,832",FALSE
+Alaska,Petersburg,23,Northwest Arctic,"7,621",FALSE
+Alaska,Prince of Wales-Hyder,46,Petersburg,"3,266",FALSE
+Alaska,Sitka,145,Prince of Wales-Hyder,"6,203",FALSE
+Alaska,Skagway,8,Sitka,"8,493",FALSE
+Alaska,Southeast Fairbanks,206,Skagway,"1,183",FALSE
+Alaska,Unassigned,118,Southeast Fairbanks,"6,893",FALSE
+Arkansas,Saline,4170,St. Francis,"24,994",FALSE
+Arkansas,Scott,323,Saline,"122,437",FALSE
+Arkansas,Searcy,268,Scott,"10,281",FALSE
+Arkansas,Sebastian,6467,Searcy,"7,881",FALSE
+Arkansas,Sevier,1630,Sebastian,"127,827",FALSE
+Arkansas,Sharp,604,Sevier,"17,007",FALSE
+Arkansas,St. Francis,1959,Sharp,"17,442",FALSE
+California,Los Angeles,357451,LosAngeles,"10,039,107",FALSE
+Colorado,El Paso,21308,Elbert,"26,729",FALSE
+Colorado,Elbert,475,El Paso,"720,403",FALSE
+Colorado,La Plata,753,Lake,"8,127",FALSE
+Colorado,Lake,224,La Plata,"56,221",FALSE
+Florida,Santa Rosa,6903,St. Johns,"264,672",FALSE
+Florida,Sarasota,12121,St. Lucie,"328,297",FALSE
+Florida,Seminole,11993,Santa Rosa,"184,313",FALSE
+Florida,St. Johns,7881,Sarasota,"433,742",FALSE
+Florida,St. Lucie,10148,Seminole,"471,826",FALSE
+Georgia,DeKalb,25917,Decatur,"26,404",FALSE
+Georgia,Decatur,1551,DeKalb,"759,297",FALSE
+Georgia,Macon,321,McDuffie,"21,312",FALSE
+Georgia,Madison,1047,McIntosh,"14,378",FALSE
+Georgia,Marion,239,Macon,"12,947",FALSE
+Georgia,McDuffie,909,Madison,"29,880",FALSE
+Georgia,McIntosh,365,Marion,"8,359",FALSE
+Illinois,De Witt,554,DeKalb,"104,897",FALSE
+Illinois,DeKalb,4415,De Witt,"15,638",FALSE
+Illinois,LaSalle,5331,Lake,"696,535",FALSE
+Illinois,Lake,33260,LaSalle,"108,669",FALSE
+Illinois,Macon,5774,McDonough,"29,682",FALSE
+Illinois,Macoupin,1828,McHenry,"307,774",FALSE
+Illinois,Madison,12394,McLean,"171,517",FALSE
+Illinois,Marion,2135,Macon,"104,009",FALSE
+Illinois,Marshall,320,Macoupin,"44,926",FALSE
+Illinois,Mason,580,Madison,"262,966",FALSE
+Illinois,Massac,422,Marion,"37,205",FALSE
+Illinois,McDonough,1433,Marshall,"11,438",FALSE
+Illinois,McHenry,12483,Mason,"13,359",FALSE
+Illinois,McLean,7408,Massac,"13,772",FALSE
+Illinois,Saline,999,St. Clair,"259,686",FALSE
+Illinois,Sangamon,8669,Saline,"23,491",FALSE
+Illinois,Schuyler,222,Sangamon,"194,672",FALSE
+Illinois,Scott,207,Schuyler,"6,768",FALSE
+Illinois,Shelby,1161,Scott,"4,951",FALSE
+Illinois,St. Clair,11447,Shelby,"21,634",FALSE
+Indiana,DeKalb,1617,Dearborn,"49,458",FALSE
+Indiana,Dearborn,1934,Decatur,"26,559",FALSE
+Indiana,Decatur,1162,DeKalb,"43,475",FALSE
+Indiana,LaPorte,4194,Lake,"485,493",FALSE
+Indiana,Lake,25026,LaPorte,"109,888",FALSE
+Indiana,Scott,919,St. Joseph,"271,826",FALSE
+Indiana,Shelby,1608,Scott,"23,873",FALSE
+Indiana,Spencer,742,Shelby,"44,729",FALSE
+Indiana,St. Joseph,15539,Spencer,"20,277",FALSE
+Kansas,Marion,373,McPherson,"28,542",FALSE
+Kansas,Marshall,362,Marion,"11,884",FALSE
+Kansas,McPherson,1157,Marshall,"9,707",FALSE
+Kentucky,Madison,3281,McCracken,"65,418",FALSE
+Kentucky,Magoffin,353,McCreary,"17,231",FALSE
+Kentucky,Marion,827,McLean,"9,207",FALSE
+Kentucky,Marshall,811,Madison,"92,987",FALSE
+Kentucky,Martin,358,Magoffin,"12,161",FALSE
+Kentucky,Mason,321,Marion,"19,273",FALSE
+Kentucky,McCracken,2173,Marshall,"31,100",FALSE
+Kentucky,McCreary,331,Martin,"11,195",FALSE
+Kentucky,McLean,343,Mason,"17,070",FALSE
+Louisiana,LaSalle,819,Lafayette,"244,390",FALSE
+Louisiana,Lafayette,11146,Lafourche,"97,614",FALSE
+Louisiana,Lafourche,4455,LaSalle,"14,892",FALSE
+Maryland,Somerset,636,St. Mary's,"113,510",FALSE
+Maryland,St. Mary's,1851,Somerset,"25,616",FALSE
+Michigan,Sanilac,517,St. Clair,"159,128",FALSE
+Michigan,Schoolcraft,163,St. Joseph,"60,964",FALSE
+Michigan,Shiawassee,1573,Sanilac,"41,170",FALSE
+Michigan,St. Clair,3527,Schoolcraft,"8,094",FALSE
+Michigan,St. Joseph,2228,Shiawassee,"68,122",FALSE
+Minnesota,Scott,6884,St. Louis,"199,070",FALSE
+Minnesota,Sherburne,4734,Scott,"149,013",FALSE
+Minnesota,Sibley,632,Sherburne,"97,238",FALSE
+Minnesota,St. Louis,6766,Sibley,"14,865",FALSE
+Missouri,Macon,544,McDonald,"22,837",FALSE
+Missouri,Madison,736,Macon,"15,117",FALSE
+Missouri,Maries,324,Madison,"12,088",FALSE
+Missouri,Marion,1549,Maries,"8,697",FALSE
+Missouri,McDonald,1340,Marion,"28,530",FALSE
+Montana,Madison,369,McCone,"1,664",FALSE
+Montana,McCone,82,Madison,"8,600",FALSE
+Nebraska,Madison,2808,McPherson,494,FALSE
+Nebraska,McPherson,15,Madison,"35,099",FALSE
+New Mexico,San Juan,4807,Sandoval,"146,748",FALSE
+New Mexico,San Miguel,340,San Juan,"123,958",FALSE
+New Mexico,Sandoval,3797,San Miguel,"27,277",FALSE
+New York,Saratoga,1842,St. Lawrence,"107,740",FALSE
+New York,Schenectady,1997,Saratoga,"229,863",FALSE
+New York,Schoharie,162,Schenectady,"155,299",FALSE
+New York,Schuyler,248,Schoharie,"30,999",FALSE
+New York,Seneca,232,Schuyler,"17,807",FALSE
+New York,St. Lawrence,649,Seneca,"34,016",FALSE
+North Carolina,Macon,886,McDowell,"45,756",FALSE
+North Carolina,Madison,428,Macon,"35,858",FALSE
+North Carolina,Martin,774,Madison,"21,755",FALSE
+North Carolina,McDowell,1647,Martin,"22,440",FALSE
+Oklahoma,Major,367,McClain,"40,474",FALSE
+Oklahoma,Marshall,581,McCurtain,"32,832",FALSE
+Oklahoma,Mayes,1358,McIntosh,"19,596",FALSE
+Oklahoma,McClain,2097,Major,"7,629",FALSE
+Oklahoma,McCurtain,2143,Marshall,"16,931",FALSE
+Oklahoma,McIntosh,719,Mayes,"41,100",FALSE
+South Carolina,Marion,1277,McCormick,"9,463",FALSE
+South Carolina,Marlboro,1313,Marion,"30,657",FALSE
+South Carolina,McCormick,315,Marlboro,"26,118",FALSE
+South Dakota,Marshall,138,McCook,"5,586",FALSE
+South Dakota,McCook,546,McPherson,"2,379",FALSE
+South Dakota,McPherson,122,Marshall,"4,935",FALSE
+Tennessee,DeKalb,1056,Decatur,"11,663",FALSE
+Tennessee,Decatur,885,DeKalb,"20,490",FALSE
+Tennessee,Macon,1726,McMinn,"53,794",FALSE
+Tennessee,Madison,4964,McNairy,"25,694",FALSE
+Tennessee,Marion,1014,Macon,"24,602",FALSE
+Tennessee,Marshall,1577,Madison,"97,984",FALSE
+Tennessee,Maury,5266,Marion,"28,907",FALSE
+Tennessee,McMinn,2271,Marshall,"34,375",FALSE
+Tennessee,McNairy,1357,Maury,"96,387",FALSE
+Texas,DeWitt,1167,Deaf Smith,"18,546",FALSE
+Texas,Deaf Smith,1219,Delta,"5,331",FALSE
+Texas,Delta,46,Denton,"887,207",FALSE
+Texas,Denton,18141,DeWitt,"20,160",FALSE
+Texas,El Paso,79162,Ellis,"184,826",FALSE
+Texas,Ellis,6070,El Paso,"839,238",FALSE
+Texas,La Salle,388,Lamar,"49,859",FALSE
+Texas,Lamar,2385,Lamb,"12,893",FALSE
+Texas,Lamb,876,Lampasas,"21,428",FALSE
+Texas,Lampasas,356,La Salle,"7,520",FALSE
+Texas,Madison,854,McCulloch,"7,984",FALSE
+Texas,Marion,182,McLennan,"256,623",FALSE
+Texas,Martin,170,McMullen,743,FALSE
+Texas,Mason,133,Madison,"14,284",FALSE
+Texas,Matagorda,1199,Marion,"9,854",FALSE
+Texas,Maverick,4722,Martin,"5,771",FALSE
+Texas,McCulloch,274,Mason,"4,274",FALSE
+Texas,McLennan,12947,Matagorda,"36,643",FALSE
+Texas,McMullen,27,Maverick,"58,722",FALSE
+Virginia,King George,354,King and Queen,"7,025",FALSE
+Virginia,King William,263,King George,"26,836",FALSE
+Virginia,King and Queen,100,King William,"17,148",FALSE
+West Virginia,Marion,667,McDowell,"17,624",FALSE
+West Virginia,Marshall,961,Marion,"56,072",FALSE
+West Virginia,Mason,309,Marshall,"30,531",FALSE
+West Virginia,McDowell,557,Mason,"26,516",FALSE
+Wisconsin,Sauk,3252,St. Croix,"90,687",FALSE
+Wisconsin,Sawyer,760,Sauk,"64,442",FALSE
+Wisconsin,Shawano,3608,Sawyer,"16,558",FALSE
+Wisconsin,Sheboygan,8447,Shawano,"40,899",FALSE
+Wisconsin,St. Croix,3990,Sheboygan,"115,340",FALSE
+Alaska,Bristol Bay plus Lake and Peninsula,141,Bristol Bay plus Lake and Peninsula,836,TRUE
+California,San Bernardino,81328,San Bernardino,"2,180,085",TRUE
+California,San Diego,69231,San Diego,"3,338,330",TRUE
+California,San Francisco,14251,San Francisco,"881,549",TRUE
+California,San Joaquin,24450,San Joaquin,"762,148",TRUE
+California,San Luis Obispo,5486,San Luis Obispo,"283,111",TRUE
+California,San Mateo,12988,San Mateo,"766,573",TRUE
+California,Santa Barbara,10768,Santa Barbara,"446,499",TRUE
+California,Santa Clara,30025,Santa Clara,"1,927,852",TRUE
+California,Santa Cruz,3685,Santa Cruz,"273,213",TRUE
+Colorado,Clear Creek,159,Clear Creek,"9,700",TRUE
+Colorado,Kit Carson,247,Kit Carson,"7,097",TRUE
+Colorado,Las Animas,152,Las Animas,"14,506",TRUE
+Colorado,Rio Blanco,84,Rio Blanco,"6,324",TRUE
+Colorado,Rio Grande,188,Rio Grande,"11,267",TRUE
+Colorado,San Juan,19,San Juan,728,TRUE
+Colorado,San Miguel,174,San Miguel,"8,179",TRUE
+Connecticut,New Haven,25248,New Haven,"854,757",TRUE
+Connecticut,New London,5352,New London,"265,206",TRUE
+Delaware,New Castle,16900,New Castle,"558,753",TRUE
+District of Columbia,District of Columbia,19808,District of Columbia,"705,749",TRUE
+Florida,Indian River,4668,Indian River,"159,923",TRUE
+Florida,Miami-Dade,211257,Miami-Dade,"2,716,940",TRUE
+Florida,Palm Beach,60729,Palm Beach,"1,496,770",TRUE
+Georgia,Ben Hill,982,Ben Hill,"16,700",TRUE
+Georgia,Jeff Davis,943,Jeff Davis,"15,115",TRUE
+Idaho,Bear Lake,157,Bear Lake,"6,125",TRUE
+Idaho,Nez Perce,1990,Nez Perce,"40,408",TRUE
+Idaho,Twin Falls,6312,Twin Falls,"86,878",TRUE
+Illinois,Jo Daviess,949,Jo Daviess,"21,235",TRUE
+Illinois,Rock Island,7606,Rock Island,"141,879",TRUE
+Iowa,Black Hawk,10005,Black Hawk,"131,228",TRUE
+Iowa,Buena Vista,2865,Buena Vista,"19,620",TRUE
+Iowa,Cerro Gordo,3110,Cerro Gordo,"42,450",TRUE
+Iowa,Des Moines,2591,Des Moines,"38,967",TRUE
+Iowa,O'Brien,1163,O'Brien,"13,753",TRUE
+Iowa,Palo Alto,585,Palo Alto,"8,886",TRUE
+Iowa,Van Buren,322,Van Buren,"7,044",TRUE
+Louisiana,Acadia,3678,Acadia,"62,045",TRUE
+Louisiana,Allen,2046,Allen,"25,627",TRUE
+Louisiana,Ascension,5325,Ascension,"126,604",TRUE
+Louisiana,Assumption,972,Assumption,"21,891",TRUE
+Louisiana,Avoyelles,1997,Avoyelles,"40,144",TRUE
+Louisiana,Beauregard,1270,Beauregard,"37,497",TRUE
+Louisiana,Bienville,726,Bienville,"13,241",TRUE
+Louisiana,Bossier,5774,Bossier,"127,039",TRUE
+Louisiana,Caddo,12329,Caddo,"240,204",TRUE
+Louisiana,Calcasieu,9924,Calcasieu,"203,436",TRUE
+Louisiana,Caldwell,593,Caldwell,"9,918",TRUE
+Louisiana,Cameron,272,Cameron,"6,973",TRUE
+Louisiana,Catahoula,582,Catahoula,"9,494",TRUE
+Louisiana,Claiborne,715,Claiborne,"15,670",TRUE
+Louisiana,Concordia,911,Concordia,"19,259",TRUE
+Louisiana,De Soto,1178,De Soto,"27,463",TRUE
+Louisiana,East Baton Rouge,18764,East Baton Rouge,"440,059",TRUE
+Louisiana,East Carroll,670,East Carroll,"6,861",TRUE
+Louisiana,East Feliciana,2048,East Feliciana,"19,135",TRUE
+Louisiana,Evangeline,1753,Evangeline,"33,395",TRUE
+Louisiana,Franklin,1653,Franklin,"20,015",TRUE
+Louisiana,Grant,664,Grant,"22,389",TRUE
+Louisiana,Iberia,3446,Iberia,"69,830",TRUE
+Louisiana,Iberville,1799,Iberville,"32,511",TRUE
+Alaska,Ketchikan Gateway,183,Ketchikan Gateway,"13,901",TRUE
+Alaska,Kodiak Island,203,Kodiak Island,"12,998",TRUE
+Alaska,Kusilvak,374,Kusilvak,"8,314",TRUE
+Alaska,Valdez-Cordova,232,Valdez-Cordova,"9,202",TRUE
+Alaska,Wrangell,20,Wrangell,"2,502",TRUE
+Alaska,Yakutat,44,Yakutat,579,TRUE
+Alaska,Yukon-Koyukuk,150,Yukon-Koyukuk,"5,230",TRUE
+Arizona,La Paz,740,La Paz,"21,108",TRUE
+Arizona,Santa Cruz,3468,Santa Cruz,"46,498",TRUE
+Arkansas,Hot Spring,2729,Hot Spring,"33,771",TRUE
+Arkansas,Little River,601,Little River,"12,259",TRUE
+Arkansas,Van Buren,307,Van Buren,"16,545",TRUE
+California,Contra Costa,21959,Contra Costa,"1,153,526",TRUE
+California,Del Norte,259,Del Norte,"27,812",TRUE
+California,El Dorado,1899,El Dorado,"192,843",TRUE
+California,San Benito,1694,San Benito,"62,808",TRUE
+Louisiana,Jackson,1098,Jackson,"15,744",TRUE
+Louisiana,Jefferson,20927,Jefferson,"432,493",TRUE
+Louisiana,Jefferson Davis,1603,Jefferson Davis,"31,368",TRUE
+Louisiana,Lincoln,2318,Lincoln,"46,742",TRUE
+Louisiana,Livingston,5456,Livingston,"140,789",TRUE
+Louisiana,Madison,1018,Madison,"10,951",TRUE
+Louisiana,Morehouse,1197,Morehouse,"24,874",TRUE
+Louisiana,Natchitoches,1909,Natchitoches,"38,158",TRUE
+Louisiana,Orleans,14978,Orleans,"390,144",TRUE
+Louisiana,Ouachita,9267,Ouachita,"153,279",TRUE
+Louisiana,Plaquemines,1057,Plaquemines,"23,197",TRUE
+Louisiana,Pointe Coupee,1302,Pointe Coupee,"21,730",TRUE
+Louisiana,Rapides,5948,Rapides,"129,648",TRUE
+Louisiana,Red River,551,Red River,"8,442",TRUE
+Louisiana,Richland,1323,Richland,"20,122",TRUE
+Louisiana,Sabine,1320,Sabine,"23,884",TRUE
+Louisiana,St. Bernard,1715,St. Bernard,"47,244",TRUE
+Louisiana,St. Charles,2391,St. Charles,"53,100",TRUE
+Louisiana,St. Helena,501,St. Helena,"10,132",TRUE
+Louisiana,St. James,934,St. James,"21,096",TRUE
+Louisiana,St. John the Baptist,1873,St. John the Baptist,"42,837",TRUE
+Louisiana,St. Landry,4597,St. Landry,"82,124",TRUE
+Louisiana,St. Martin,2545,St. Martin,"53,431",TRUE
+Louisiana,St. Mary,2271,St. Mary,"49,348",TRUE
+Louisiana,St. Tammany,9514,St. Tammany,"260,419",TRUE
+Louisiana,Tangipahoa,6190,Tangipahoa,"134,758",TRUE
+Louisiana,Tensas,205,Tensas,"4,334",TRUE
+Louisiana,Terrebonne,4303,Terrebonne,"110,461",TRUE
+Louisiana,Union,1338,Union,"22,108",TRUE
+Louisiana,Vermilion,2404,Vermilion,"59,511",TRUE
+Louisiana,Vernon,1327,Vernon,"47,429",TRUE
+Louisiana,Washington,2150,Washington,"46,194",TRUE
+Louisiana,Webster,1844,Webster,"38,340",TRUE
+Louisiana,West Baton Rouge,1228,West Baton Rouge,"26,465",TRUE
+Louisiana,West Carroll,556,West Carroll,"10,830",TRUE
+Louisiana,West Feliciana,779,West Feliciana,"15,568",TRUE
+Louisiana,Winn,906,Winn,"13,904",TRUE
+Alaska,Aleutians East,21,Aleutians East,"3,337",TRUE
+Alaska,Aleutians West,106,Aleutians West,"5,634",TRUE
+Alaska,Anchorage,14063,Anchorage,"288,000",TRUE
+Alaska,Bethel,1085,Bethel,"18,386",TRUE
+Alaska,Denali,40,Denali,"2,097",TRUE
+Alaska,Dillingham,90,Dillingham,"4,916",TRUE
+Alaska,Fairbanks North Star,3034,Fairbanks North Star,"96,849",TRUE
+Alaska,Haines,16,Haines,"2,530",TRUE
+Alaska,Hoonah-Angoon,0,Hoonah-Angoon,"2,148",TRUE
+Alaska,Juneau,776,Juneau,"31,974",TRUE
+Alaska,Kenai Peninsula,2009,Kenai Peninsula,"58,708",TRUE
+Maryland,Anne Arundel,15103,Anne Arundel,"579,234",TRUE
+Maryland,Baltimore City,22010,Baltimore City,"593,490",TRUE
+Maryland,Prince George's,38053,Prince George's,"909,327",TRUE
+Maryland,Queen Anne's,990,Queen Anne's,"50,381",TRUE
+Massachusetts,Dukes and Nantucket,486,Dukes and Nantucket,"28,731",TRUE
+Michigan,Grand Traverse,1517,Grand Traverse,"93,088",TRUE
+Michigan,Presque Isle,184,Presque Isle,"12,592",TRUE
+Michigan,Van Buren,2274,Van Buren,"75,677",TRUE
+Minnesota,Big Stone,260,Big Stone,"4,991",TRUE
+Minnesota,Blue Earth,3525,Blue Earth,"67,653",TRUE
+Minnesota,Crow Wing,2908,Crow Wing,"65,055",TRUE
+Minnesota,Lac qui Parle,295,Lac qui Parle,"6,623",TRUE
+Minnesota,Lake of the Woods,78,Lake of the Woods,"3,740",TRUE
+Minnesota,Le Sueur,1209,Le Sueur,"28,887",TRUE
+Minnesota,Mille Lacs,1201,Mille Lacs,"26,277",TRUE
+Minnesota,Otter Tail,2328,Otter Tail,"58,746",TRUE
+Minnesota,Red Lake,167,Red Lake,"4,055",TRUE
+Minnesota,Yellow Medicine,508,Yellow Medicine,"9,709",TRUE
+Mississippi,Jefferson Davis,528,Jefferson Davis,"11,128",TRUE
+Mississippi,Pearl River,1385,Pearl River,"55,535",TRUE
+Missouri,Cape Girardeau,4407,Cape Girardeau,"78,871",TRUE
+Missouri,New Madrid,1204,New Madrid,"17,076",TRUE
+Missouri,St. Charles,17328,St. Charles,"402,022",TRUE
+Missouri,St. Clair,282,St. Clair,"9,397",TRUE
+Missouri,St. Francois,4499,St. Francois,"67,215",TRUE
+Missouri,St. Louis,44897,St. Louis,"994,205",TRUE
+Missouri,St. Louis City,11393,St. Louis City,"300,576",TRUE
+Missouri,Ste. Genevieve,909,Ste. Genevieve,"17,894",TRUE
+Montana,Big Horn,1738,Big Horn,"13,319",TRUE
+Montana,Deer Lodge,656,Deer Lodge,"9,140",TRUE
+Montana,Golden Valley,22,Golden Valley,821,TRUE
+Montana,Judith Basin,46,Judith Basin,"2,007",TRUE
+Montana,Lewis and Clark,2152,Lewis and Clark,"69,432",TRUE
+Montana,Powder River,79,Powder River,"1,682",TRUE
+Montana,Silver Bow,1639,Silver Bow,"34,915",TRUE
+Montana,Sweet Grass,212,Sweet Grass,"3,737",TRUE
+Nebraska,Box Butte,517,Box Butte,"10,783",TRUE
+Nebraska,Keya Paha,17,Keya Paha,806,TRUE
+Nebraska,Red Willow,507,Red Willow,"10,724",TRUE
+Nebraska,Scotts Bluff,2493,Scotts Bluff,"35,618",TRUE
+Nevada,Carson City,1545,Carson City,"55,916",TRUE
+Nevada,White Pine,218,White Pine,"9,580",TRUE
+New Jersey,Cape May,1498,Cape May,"92,039",TRUE
+New Mexico,De Baca,30,De Baca,"1,748",TRUE
+New Mexico,Dona Ana,11567,Dona Ana,"218,195",TRUE
+New Mexico,Los Alamos,106,Los Alamos,"19,369",TRUE
+New Mexico,Rio Arriba,1028,Rio Arriba,"38,921",TRUE
+New Mexico,Santa Fe,3977,Santa Fe,"150,358",TRUE
+New York,New York,41620,New York,"1,628,706",TRUE
+North Carolina,New Hanover,6421,New Hanover,"234,473",TRUE
+North Dakota,Golden Valley,146,Golden Valley,"1,761",TRUE
+North Dakota,Grand Forks,7475,Grand Forks,"69,451",TRUE
+Ohio,Van Wert,811,Van Wert,"28,275",TRUE
+Oklahoma,Le Flore,2213,Le Flore,"49,853",TRUE
+Oklahoma,Roger Mills,134,Roger Mills,"3,583",TRUE
+Oregon,Hood River,349,Hood River,"23,382",TRUE
+South Dakota,Bon Homme,1288,Bon Homme,"6,901",TRUE
+South Dakota,Charles Mix,703,Charles Mix,"9,292",TRUE
+South Dakota,Fall River,340,Fall River,"6,713",TRUE
+South Dakota,Oglala Lakota,1498,Oglala Lakota,"14,177",TRUE
+Tennessee,Van Buren,317,Van Buren,"5,872",TRUE
+Texas,Fort Bend,19223,Fort Bend,"811,688",TRUE
+Texas,Jeff Davis,43,Jeff Davis,"2,274",TRUE
+Texas,Jim Hogg,206,Jim Hogg,"5,200",TRUE
+Texas,Jim Wells,1894,Jim Wells,"40,482",TRUE
+Texas,Live Oak,418,Live Oak,"12,207",TRUE
+Texas,Palo Pinto,882,Palo Pinto,"29,189",TRUE
+Texas,Red River,216,Red River,"12,023",TRUE
+Texas,San Augustine,256,San Augustine,"8,237",TRUE
+Texas,San Jacinto,250,San Jacinto,"28,859",TRUE
+Texas,San Patricio,1747,San Patricio,"66,730",TRUE
+Texas,San Saba,294,San Saba,"6,055",TRUE
+Texas,Tom Green,7954,Tom Green,"119,200",TRUE
+Texas,Val Verde,2932,Val Verde,"49,025",TRUE
+Texas,Van Zandt,1017,Van Zandt,"56,590",TRUE
+Utah,Box Elder,8634,Box Elder,"56,046",TRUE
+Utah,Salt Lake,71088,Salt Lake,"1,160,437",TRUE
+Utah,San Juan,970,San Juan,"15,308",TRUE
+Vermont,Grand Isle,36,Grand Isle,"7,235",TRUE
+Virginia,Harrisonburg,3319,Harrisonburg,"53,016",TRUE
+Virginia,Alexandria,4831,Alexandria,"159,428",TRUE
+Virginia,Bristol,473,Bristol,"16,762",TRUE
+Virginia,Buena Vista,209,Buena Vista,"6,478",TRUE
+Virginia,Charles City,127,Charles City,"6,963",TRUE
+Virginia,Charlottesville,1777,Charlottesville,"47,266",TRUE
+Virginia,Chesapeake,5799,Chesapeake,"244,835",TRUE
+Virginia,Colonial Heights,369,Colonial Heights,"17,370",TRUE
+Virginia,Covington,112,Covington,"5,538",TRUE
+Virginia,Danville,1492,Danville,"40,044",TRUE
+Virginia,Emporia,309,Emporia,"5,346",TRUE
+Virginia,Fairfax City,193,Fairfax City,"24,019",TRUE
+Virginia,Falls Church,88,Falls Church,"14,617",TRUE
+Virginia,Franklin City,533,Franklin City,"7,967",TRUE
+Virginia,Fredericksburg,643,Fredericksburg,"29,036",TRUE
+Virginia,Galax,518,Galax,"6,347",TRUE
+Virginia,Hampton,2506,Hampton,"134,510",TRUE
+Virginia,Hopewell,576,Hopewell,"22,529",TRUE
+Virginia,Isle of Wight,957,Isle of Wight,"37,109",TRUE
+Virginia,James City,1090,James City,"76,523",TRUE
+Virginia,Lexington,315,Lexington,"7,446",TRUE
+Virginia,Lynchburg,2446,Lynchburg,"82,168",TRUE
+Virginia,Manassas,2183,Manassas,"41,085",TRUE
+Virginia,Manassas Park,689,Manassas Park,"17,478",TRUE
+Virginia,Martinsville,608,Martinsville,"12,554",TRUE
+Virginia,New Kent,351,New Kent,"23,091",TRUE
+Virginia,Newport News,3688,Newport News,"179,225",TRUE
+Virginia,Norfolk,6144,Norfolk,"242,742",TRUE
+Virginia,Norton,65,Norton,"3,981",TRUE
+Virginia,Petersburg,1031,Petersburg,"31,346",TRUE
+Virginia,Poquoson,122,Poquoson,"12,271",TRUE
+Virginia,Portsmouth,3053,Portsmouth,"94,398",TRUE
+Virginia,Prince Edward,841,Prince Edward,"22,802",TRUE
+Virginia,Prince George,1348,Prince George,"38,353",TRUE
+Virginia,Prince William,16595,Prince William,"470,335",TRUE
+Virginia,Radford,1085,Radford,"18,249",TRUE
+Virginia,Richmond City,6215,Richmond City,"230,436",TRUE
+Virginia,Roanoke City,3772,Roanoke City,"99,143",TRUE
+Virginia,Salem,791,Salem,"25,301",TRUE
+Virginia,Staunton,548,Staunton,"24,932",TRUE
+Virginia,Suffolk,2582,Suffolk,"92,108",TRUE
+Virginia,Virginia Beach,9716,Virginia Beach,"449,974",TRUE
+Virginia,Waynesboro,502,Waynesboro,"22,630",TRUE
+Virginia,Williamsburg,275,Williamsburg,"14,954",TRUE
+Virginia,Winchester,847,Winchester,"28,078",TRUE
+Washington,Grays Harbor,904,Grays Harbor,"75,061",TRUE
+Washington,Pend Oreille,190,Pend Oreille,"13,724",TRUE
+Washington,San Juan,55,San Juan,"17,582",TRUE
+Washington,Walla Walla,1865,Walla Walla,"60,760",TRUE
+Wisconsin,Eau Claire,7018,Eau Claire,"104,646",TRUE
+Wisconsin,Fond du Lac,8097,Fond du Lac,"103,403",TRUE
+Wisconsin,Green Lake,1310,Green Lake,"18,913",TRUE
+Wisconsin,La Crosse,7340,La Crosse,"118,016",TRUE
+Wyoming,Big Horn,418,Big Horn,"11,790",TRUE
+Wyoming,Hot Springs,117,Hot Springs,"4,413",TRUE
+Alabama,Autauga,2580,Autauga,"55,869",TRUE
+Alabama,Baldwin,8038,Baldwin,"223,234",TRUE
+Alabama,Barbour,1151,Barbour,"24,686",TRUE
+Alabama,Bibb,1024,Bibb,"22,394",TRUE
+Alabama,Blount,2704,Blount,"57,826",TRUE
+Alabama,Bullock,684,Bullock,"10,101",TRUE
+Alabama,Butler,1120,Butler,"19,448",TRUE
+Alabama,Calhoun,5896,Calhoun,"113,605",TRUE
+Alabama,Chambers,1663,Chambers,"33,254",TRUE
+Alabama,Cherokee,959,Cherokee,"26,196",TRUE
+Alabama,Chilton,2125,Chilton,"44,428",TRUE
+Alabama,Choctaw,413,Choctaw,"12,589",TRUE
+Alabama,Clarke,1536,Clarke,"23,622",TRUE
+Alabama,Clay,876,Clay,"13,235",TRUE
+Alabama,Cleburne,705,Cleburne,"14,910",TRUE
+Alabama,Coffee,2265,Coffee,"52,342",TRUE
+Alabama,Colbert,2880,Colbert,"55,241",TRUE
+Alabama,Conecuh,667,Conecuh,"12,067",TRUE
+Alabama,Coosa,299,Coosa,"10,663",TRUE
+Alabama,Covington,2104,Covington,"37,049",TRUE
+Alabama,Crenshaw,698,Crenshaw,"13,772",TRUE
+Alabama,Cullman,3998,Cullman,"83,768",TRUE
+Alabama,Dale,2230,Dale,"49,172",TRUE
+Alabama,Dallas,2168,Dallas,"37,196",TRUE
+Alabama,DeKalb,4506,DeKalb,"71,513",TRUE
+Alabama,Elmore,3820,Elmore,"81,209",TRUE
+Alabama,Escambia,1934,Escambia,"36,633",TRUE
+Alabama,Etowah,5741,Etowah,"102,268",TRUE
+Alabama,Fayette,800,Fayette,"16,302",TRUE
+Alabama,Franklin,2394,Franklin,"31,362",TRUE
+Alabama,Geneva,1145,Geneva,"26,271",TRUE
+Alabama,Greene,394,Greene,"8,111",TRUE
+Alabama,Hale,907,Hale,"14,651",TRUE
+Alabama,Henry,833,Henry,"17,205",TRUE
+Alabama,Houston,4945,Houston,"105,882",TRUE
+Alabama,Jackson,2837,Jackson,"51,626",TRUE
+Alabama,Jefferson,29626,Jefferson,"658,573",TRUE
+Alabama,Lamar,601,Lamar,"13,805",TRUE
+Alabama,Lauderdale,3653,Lauderdale,"92,729",TRUE
+Alabama,Lawrence,1179,Lawrence,"32,924",TRUE
+Alabama,Lee,7421,Lee,"164,542",TRUE
+Alabama,Limestone,3901,Limestone,"98,915",TRUE
+Alabama,Lowndes,771,Lowndes,"9,726",TRUE
+Alabama,Macon,684,Macon,"18,068",TRUE
+Alabama,Madison,11958,Madison,"372,909",TRUE
+Alabama,Marengo,1159,Marengo,"18,863",TRUE
+Alabama,Marion,1320,Marion,"29,709",TRUE
+Alabama,Marshall,5660,Marshall,"96,774",TRUE
+Alabama,Mobile,19090,Mobile,"413,210",TRUE
+Alabama,Monroe,758,Monroe,"20,733",TRUE
+Alabama,Montgomery,11903,Montgomery,"226,486",TRUE
+Alabama,Morgan,5913,Morgan,"119,679",TRUE
+Alabama,Perry,656,Perry,"8,923",TRUE
+Alabama,Pickens,1119,Pickens,"19,930",TRUE
+Alabama,Pike,1529,Pike,"33,114",TRUE
+Alabama,Randolph,972,Randolph,"22,722",TRUE
+Alabama,Russell,2126,Russell,"57,961",TRUE
+Alabama,Sumter,547,Sumter,"12,427",TRUE
+Alabama,Talladega,3292,Talladega,"79,978",TRUE
+Alabama,Tallapoosa,1668,Tallapoosa,"40,367",TRUE
+Alabama,Tuscaloosa,12274,Tuscaloosa,"209,355",TRUE
+Alabama,Walker,3424,Walker,"63,521",TRUE
+Alabama,Washington,891,Washington,"16,326",TRUE
+Alabama,Wilcox,619,Wilcox,"10,373",TRUE
+Alabama,Winston,1192,Winston,"23,629",TRUE
+Arizona,Apache,4741,Apache,"71,887",TRUE
+Arizona,Cochise,3020,Cochise,"125,922",TRUE
+Arizona,Coconino,6765,Coconino,"143,476",TRUE
+Arizona,Gila,2514,Gila,"54,018",TRUE
+Arizona,Graham,1815,Graham,"38,837",TRUE
+Arizona,Greenlee,154,Greenlee,"9,498",TRUE
+Arizona,Maricopa,185580,Maricopa,"4,485,414",TRUE
+Arizona,Mohave,5482,Mohave,"212,181",TRUE
+Arizona,Navajo,7444,Navajo,"110,924",TRUE
+Arizona,Pima,34985,Pima,"1,047,279",TRUE
+Arizona,Pinal,14851,Pinal,"462,789",TRUE
+Arizona,Yavapai,4095,Yavapai,"235,099",TRUE
+Arizona,Yuma,16042,Yuma,"213,787",TRUE
+Arkansas,Arkansas,894,Arkansas,"17,486",TRUE
+Arkansas,Ashley,724,Ashley,"19,657",TRUE
+Arkansas,Baxter,1216,Baxter,"41,932",TRUE
+Arkansas,Benton,10906,Benton,"279,141",TRUE
+Arkansas,Boone,1522,Boone,"37,432",TRUE
+Arkansas,Bradley,420,Bradley,"10,763",TRUE
+Arkansas,Calhoun,125,Calhoun,"5,189",TRUE
+Arkansas,Carroll,1259,Carroll,"28,380",TRUE
+Arkansas,Chicot,1119,Chicot,"10,118",TRUE
+Arkansas,Clark,734,Clark,"22,320",TRUE
+Arkansas,Clay,755,Clay,"14,551",TRUE
+Arkansas,Cleburne,635,Cleburne,"24,919",TRUE
+Arkansas,Cleveland,324,Cleveland,"7,956",TRUE
+Arkansas,Columbia,952,Columbia,"23,457",TRUE
+Arkansas,Conway,582,Conway,"20,846",TRUE
+Arkansas,Craighead,6423,Craighead,"110,332",TRUE
+Arkansas,Crawford,2818,Crawford,"63,257",TRUE
+Arkansas,Crittenden,3043,Crittenden,"47,955",TRUE
+Arkansas,Cross,740,Cross,"16,419",TRUE
+Arkansas,Dallas,255,Dallas,"7,009",TRUE
+Arkansas,Desha,505,Desha,"11,361",TRUE
+Arkansas,Drew,558,Drew,"18,219",TRUE
+Arkansas,Faulkner,4342,Faulkner,"126,007",TRUE
+Arkansas,Franklin,698,Franklin,"17,715",TRUE
+Arkansas,Fulton,488,Fulton,"12,477",TRUE
+Arkansas,Garland,3416,Garland,"99,386",TRUE
+Arkansas,Grant,519,Grant,"18,265",TRUE
+Arkansas,Greene,2482,Greene,"45,325",TRUE
+Arkansas,Hempstead,790,Hempstead,"21,532",TRUE
+Arkansas,Howard,759,Howard,"13,202",TRUE
+Arkansas,Independence,1923,Independence,"37,825",TRUE
+Arkansas,Izard,940,Izard,"13,629",TRUE
+Arkansas,Jackson,1479,Jackson,"16,719",TRUE
+Arkansas,Jefferson,4929,Jefferson,"66,824",TRUE
+Arkansas,Johnson,1191,Johnson,"26,578",TRUE
+Arkansas,Lafayette,248,Lafayette,"6,624",TRUE
+Arkansas,Lawrence,1070,Lawrence,"16,406",TRUE
+Arkansas,Lee,1148,Lee,"8,857",TRUE
+Arkansas,Lincoln,2382,Lincoln,"13,024",TRUE
+Arkansas,Logan,822,Logan,"21,466",TRUE
+Arkansas,Lonoke,2423,Lonoke,"73,309",TRUE
+Arkansas,Madison,546,Madison,"16,576",TRUE
+Arkansas,Marion,365,Marion,"16,694",TRUE
+Arkansas,Miller,2017,Miller,"43,257",TRUE
+Arkansas,Mississippi,2960,Mississippi,"40,651",TRUE
+Arkansas,Monroe,283,Monroe,"6,701",TRUE
+Arkansas,Montgomery,235,Montgomery,"8,986",TRUE
+Arkansas,Nevada,416,Nevada,"8,252",TRUE
+Arkansas,Newton,397,Newton,"7,753",TRUE
+Arkansas,Ouachita,579,Ouachita,"23,382",TRUE
+Arkansas,Perry,222,Perry,"10,455",TRUE
+Arkansas,Phillips,874,Phillips,"17,782",TRUE
+Arkansas,Pike,344,Pike,"10,718",TRUE
+Arkansas,Poinsett,1557,Poinsett,"23,528",TRUE
+Arkansas,Polk,673,Polk,"19,964",TRUE
+Arkansas,Pope,3413,Pope,"64,072",TRUE
+Arkansas,Prairie,335,Prairie,"8,062",TRUE
+Arkansas,Pulaski,15255,Pulaski,"391,911",TRUE
+Arkansas,Randolph,907,Randolph,"17,958",TRUE
+Arkansas,Stone,439,Stone,"12,506",TRUE
+Arkansas,Union,1420,Union,"38,682",TRUE
+Arkansas,Washington,14252,Washington,"239,187",TRUE
+Arkansas,White,2663,White,"78,753",TRUE
+Arkansas,Woodruff,181,Woodruff,"6,320",TRUE
+Arkansas,Yell,1563,Yell,"21,341",TRUE
+California,Alameda,27223,Alameda,"1,671,329",TRUE
+California,Alpine,39,Alpine,"1,129",TRUE
+California,Amador,455,Amador,"39,752",TRUE
+California,Butte,3580,Butte,"219,186",TRUE
+California,Calaveras,417,Calaveras,"45,905",TRUE
+California,Colusa,623,Colusa,"21,547",TRUE
+California,Fresno,35278,Fresno,"999,101",TRUE
+California,Glenn,820,Glenn,"28,393",TRUE
+California,Humboldt,730,Humboldt,"135,558",TRUE
+California,Imperial,14720,Imperial,"181,215",TRUE
+California,Inyo,268,Inyo,"18,039",TRUE
+California,Kern,37632,Kern,"900,202",TRUE
+California,Kings,9775,Kings,"152,940",TRUE
+California,Lake,815,Lake,"64,386",TRUE
+California,Lassen,1242,Lassen,"30,573",TRUE
+California,Madera,5714,Madera,"157,327",TRUE
+California,Marin,7489,Marin,"258,826",TRUE
+California,Mariposa,94,Mariposa,"17,203",TRUE
+California,Mendocino,1368,Mendocino,"86,749",TRUE
+California,Merced,10884,Merced,"277,680",TRUE
+California,Modoc,106,Modoc,"8,841",TRUE
+California,Mono,494,Mono,"14,444",TRUE
+California,Monterey,13410,Monterey,"434,061",TRUE
+California,Napa,2641,Napa,"137,744",TRUE
+California,Nevada,948,Nevada,"99,755",TRUE
+California,Orange,68336,Orange,"3,175,692",TRUE
+California,Placer,5687,Placer,"398,329",TRUE
+California,Plumas,165,Plumas,"18,807",TRUE
+California,Riverside,78535,Riverside,"2,470,546",TRUE
+California,Sacramento,32411,Sacramento,"1,552,058",TRUE
+California,Shasta,3897,Shasta,"180,080",TRUE
+California,Sierra,17,Sierra,"3,005",TRUE
+California,Siskiyou,466,Siskiyou,"43,539",TRUE
+California,Solano,9349,Solano,"447,643",TRUE
+California,Sonoma,11316,Sonoma,"494,336",TRUE
+California,Stanislaus,19964,Stanislaus,"550,660",TRUE
+California,Sutter,2601,Sutter,"96,971",TRUE
+California,Tehama,1377,Tehama,"65,084",TRUE
+California,Trinity,106,Trinity,"12,285",TRUE
+California,Tulare,19553,Tulare,"466,195",TRUE
+California,Tuolumne,675,Tuolumne,"54,478",TRUE
+California,Ventura,17300,Ventura,"846,006",TRUE
+California,Yolo,4050,Yolo,"220,500",TRUE
+California,Yuba,1706,Yuba,"78,668",TRUE
+Colorado,Adams,25092,Adams,"517,421",TRUE
+Colorado,Alamosa,500,Alamosa,"16,233",TRUE
+Colorado,Arapahoe,22728,Arapahoe,"656,590",TRUE
+Colorado,Archuleta,129,Archuleta,"14,029",TRUE
+Colorado,Baca,51,Baca,"3,581",TRUE
+Colorado,Bent,57,Bent,"5,577",TRUE
+Colorado,Boulder,9503,Boulder,"326,196",TRUE
+Colorado,Broomfield,1704,Broomfield,"70,465",TRUE
+Colorado,Chaffee,539,Chaffee,"20,356",TRUE
+Colorado,Cheyenne,46,Cheyenne,"1,831",TRUE
+Colorado,Conejos,145,Conejos,"8,205",TRUE
+Colorado,Costilla,68,Costilla,"3,887",TRUE
+Colorado,Crowley,928,Crowley,"6,061",TRUE
+Colorado,Custer,55,Custer,"5,068",TRUE
+Colorado,Delta,425,Delta,"31,162",TRUE
+Colorado,Denver,31073,Denver,"727,211",TRUE
+Colorado,Dolores,8,Dolores,"2,055",TRUE
+Colorado,Douglas,8457,Douglas,"351,154",TRUE
+Colorado,Eagle,2012,Eagle,"55,127",TRUE
+Colorado,Fremont,1975,Fremont,"47,839",TRUE
+Colorado,Garfield,1776,Garfield,"60,061",TRUE
+Colorado,Gilpin,75,Gilpin,"6,243",TRUE
+Colorado,Grand,259,Grand,"15,734",TRUE
+Colorado,Gunnison,429,Gunnison,"17,462",TRUE
+Colorado,Hinsdale,6,Hinsdale,820,TRUE
+Colorado,Huerfano,103,Huerfano,"6,897",TRUE
+Colorado,Jackson,14,Jackson,"1,392",TRUE
+Colorado,Jefferson,16811,Jefferson,"582,881",TRUE
+Colorado,Kiowa,19,Kiowa,"1,406",TRUE
+Colorado,Larimer,8174,Larimer,"356,899",TRUE
+Colorado,Lincoln,108,Lincoln,"5,701",TRUE
+Colorado,Logan,1940,Logan,"22,409",TRUE
+Colorado,Mesa,4515,Mesa,"154,210",TRUE
+Colorado,Mineral,24,Mineral,769,TRUE
+Colorado,Moffat,202,Moffat,"13,283",TRUE
+Colorado,Montezuma,530,Montezuma,"26,183",TRUE
+Colorado,Montrose,734,Montrose,"42,758",TRUE
+Colorado,Morgan,1377,Morgan,"29,068",TRUE
+Colorado,Otero,376,Otero,"18,278",TRUE
+Colorado,Ouray,105,Ouray,"4,952",TRUE
+Colorado,Park,192,Park,"18,845",TRUE
+Colorado,Phillips,158,Phillips,"4,265",TRUE
+Colorado,Pitkin,420,Pitkin,"17,767",TRUE
+Colorado,Prowers,436,Prowers,"12,172",TRUE
+Colorado,Pueblo,6110,Pueblo,"168,424",TRUE
+Colorado,Routt,500,Routt,"25,638",TRUE
+Colorado,Saguache,195,Saguache,"6,824",TRUE
+Colorado,Sedgwick,95,Sedgwick,"2,248",TRUE
+Colorado,Summit,1242,Summit,"31,011",TRUE
+Colorado,Teller,503,Teller,"25,388",TRUE
+Colorado,Washington,182,Washington,"4,908",TRUE
+Colorado,Weld,11368,Weld,"324,492",TRUE
+Colorado,Yuma,284,Yuma,"10,019",TRUE
+Connecticut,Fairfield,33648,Fairfield,"943,332",TRUE
+Connecticut,Hartford,25182,Hartford,"891,720",TRUE
+Connecticut,Litchfield,3602,Litchfield,"180,333",TRUE
+Connecticut,Middlesex,3145,Middlesex,"162,436",TRUE
+Connecticut,Tolland,2665,Tolland,"150,721",TRUE
+Connecticut,Windham,2161,Windham,"116,782",TRUE
+Delaware,Kent,4324,Kent,"180,786",TRUE
+Delaware,Sussex,9493,Sussex,"234,225",TRUE
+Florida,Alachua,12176,Alachua,"269,043",TRUE
+Florida,Baker,1949,Baker,"29,210",TRUE
+Florida,Bay,8013,Bay,"174,705",TRUE
+Florida,Bradford,1355,Bradford,"28,201",TRUE
+Florida,Brevard,14301,Brevard,"601,942",TRUE
+Florida,Broward,99320,Broward,"1,952,778",TRUE
+Florida,Calhoun,825,Calhoun,"14,105",TRUE
+Florida,Charlotte,4576,Charlotte,"188,910",TRUE
+Florida,Citrus,4218,Citrus,"149,657",TRUE
+Florida,Clay,7278,Clay,"219,252",TRUE
+Florida,Collier,16618,Collier,"384,902",TRUE
+Florida,Columbia,4585,Columbia,"71,686",TRUE
+Florida,DeSoto,2163,DeSoto,"38,001",TRUE
+Florida,Dixie,947,Dixie,"16,826",TRUE
+Florida,Duval,39998,Duval,"957,755",TRUE
+Florida,Escambia,15732,Escambia,"318,316",TRUE
+Florida,Flagler,2511,Flagler,"115,081",TRUE
+Florida,Franklin,816,Franklin,"12,125",TRUE
+Florida,Gadsden,3198,Gadsden,"45,660",TRUE
+Florida,Gilchrist,713,Gilchrist,"18,582",TRUE
+Florida,Glades,649,Glades,"13,811",TRUE
+Florida,Gulf,1034,Gulf,"13,639",TRUE
+Florida,Hamilton,955,Hamilton,"14,428",TRUE
+Florida,Hardee,1720,Hardee,"26,937",TRUE
+Florida,Hendry,2413,Hendry,"42,022",TRUE
+Florida,Hernando,4507,Hernando,"193,920",TRUE
+Florida,Highlands,3447,Highlands,"106,221",TRUE
+Florida,Hillsborough,54792,Hillsborough,"1,471,968",TRUE
+Florida,Holmes,1084,Holmes,"19,617",TRUE
+Florida,Jackson,3661,Jackson,"46,414",TRUE
+Florida,Jefferson,730,Jefferson,"14,246",TRUE
+Florida,Lafayette,1295,Lafayette,"8,422",TRUE
+Florida,Lake,9946,Lake,"367,118",TRUE
+Florida,Lee,27585,Lee,"770,577",TRUE
+Florida,Leon,14066,Leon,"293,582",TRUE
+Florida,Levy,1319,Levy,"41,503",TRUE
+Florida,Liberty,560,Liberty,"8,354",TRUE
+Florida,Madison,1210,Madison,"18,493",TRUE
+Florida,Manatee,15511,Manatee,"403,253",TRUE
+Florida,Marion,12220,Marion,"365,579",TRUE
+Florida,Martin,5898,Martin,"161,000",TRUE
+Florida,Monroe,3064,Monroe,"74,228",TRUE
+Florida,Nassau,2865,Nassau,"88,625",TRUE
+Florida,Okaloosa,8112,Okaloosa,"210,738",TRUE
+Florida,Okeechobee,1942,Okeechobee,"42,168",TRUE
+Florida,Orange,53941,Orange,"1,393,452",TRUE
+Florida,Osceola,16891,Osceola,"375,751",TRUE
+Florida,Pasco,13373,Pasco,"553,947",TRUE
+Florida,Pinellas,30286,Pinellas,"974,996",TRUE
+Florida,Polk,26091,Polk,"724,777",TRUE
+Florida,Putnam,2607,Putnam,"74,521",TRUE
+Florida,Sumter,3248,Sumter,"132,420",TRUE
+Florida,Suwannee,3192,Suwannee,"44,417",TRUE
+Florida,Taylor,1599,Taylor,"21,569",TRUE
+Florida,Union,1205,Union,"15,237",TRUE
+Florida,Volusia,14811,Volusia,"553,284",TRUE
+Florida,Wakulla,1537,Wakulla,"33,739",TRUE
+Florida,Walton,3411,Walton,"74,071",TRUE
+Florida,Washington,1440,Washington,"25,473",TRUE
+Georgia,Appling,1315,Appling,"18,386",TRUE
+Georgia,Atkinson,575,Atkinson,"8,165",TRUE
+Georgia,Bacon,744,Bacon,"11,164",TRUE
+Georgia,Baker,121,Baker,"3,038",TRUE
+Georgia,Baldwin,2590,Baldwin,"44,890",TRUE
+Georgia,Banks,705,Banks,"19,234",TRUE
+Georgia,Barrow,3212,Barrow,"83,240",TRUE
+Georgia,Bartow,4762,Bartow,"107,738",TRUE
+Georgia,Berrien,661,Berrien,"19,397",TRUE
+Georgia,Bibb,7361,Bibb,"153,159",TRUE
+Georgia,Bleckley,696,Bleckley,"12,873",TRUE
+Georgia,Brantley,748,Brantley,"19,109",TRUE
+Georgia,Brooks,632,Brooks,"15,457",TRUE
+Georgia,Bryan,1446,Bryan,"39,627",TRUE
+Georgia,Bulloch,3674,Bulloch,"79,608",TRUE
+Georgia,Burke,1195,Burke,"22,383",TRUE
+Georgia,Butts,995,Butts,"24,936",TRUE
+Georgia,Calhoun,292,Calhoun,"6,189",TRUE
+Georgia,Camden,1711,Camden,"54,666",TRUE
+Georgia,Candler,603,Candler,"10,803",TRUE
+Georgia,Carroll,5158,Carroll,"119,992",TRUE
+Georgia,Catoosa,1894,Catoosa,"67,580",TRUE
+Georgia,Charlton,777,Charlton,"13,392",TRUE
+Georgia,Chatham,10475,Chatham,"289,430",TRUE
+Georgia,Chattahoochee,1942,Chattahoochee,"10,907",TRUE
+Georgia,Chattooga,1182,Chattooga,"24,789",TRUE
+Georgia,Cherokee,9602,Cherokee,"258,773",TRUE
+Georgia,Clarke,7602,Clarke,"128,331",TRUE
+Georgia,Clay,148,Clay,"2,834",TRUE
+Georgia,Clayton,9956,Clayton,"292,256",TRUE
+Georgia,Clinch,531,Clinch,"6,618",TRUE
+Georgia,Cobb,27899,Cobb,"760,141",TRUE
+Georgia,Coffee,2802,Coffee,"43,273",TRUE
+Georgia,Colquitt,2584,Colquitt,"45,600",TRUE
+Georgia,Columbia,6079,Columbia,"156,714",TRUE
+Georgia,Cook,828,Cook,"17,270",TRUE
+Georgia,Coweta,4745,Coweta,"148,509",TRUE
+Georgia,Crawford,240,Crawford,"12,404",TRUE
+Georgia,Crisp,903,Crisp,"22,372",TRUE
+Georgia,Dade,480,Dade,"16,116",TRUE
+Georgia,Dawson,1075,Dawson,"26,108",TRUE
+Georgia,Dodge,1052,Dodge,"20,605",TRUE
+Georgia,Dooly,468,Dooly,"13,390",TRUE
+Georgia,Dougherty,3637,Dougherty,"87,956",TRUE
+Georgia,Douglas,5253,Douglas,"146,343",TRUE
+Georgia,Early,652,Early,"10,190",TRUE
+Georgia,Echols,270,Echols,"4,006",TRUE
+Georgia,Effingham,2120,Effingham,"64,296",TRUE
+Georgia,Elbert,1098,Elbert,"19,194",TRUE
+Georgia,Emanuel,1407,Emanuel,"22,646",TRUE
+Georgia,Evans,540,Evans,"10,654",TRUE
+Georgia,Fannin,970,Fannin,"26,188",TRUE
+Georgia,Fayette,2911,Fayette,"114,421",TRUE
+Georgia,Floyd,5204,Floyd,"98,498",TRUE
+Georgia,Forsyth,6238,Forsyth,"244,252",TRUE
+Georgia,Franklin,1159,Franklin,"23,349",TRUE
+Georgia,Fulton,37930,Fulton,"1,063,937",TRUE
+Georgia,Gilmer,1218,Gilmer,"31,369",TRUE
+Georgia,Glascock,80,Glascock,"2,971",TRUE
+Georgia,Glynn,4153,Glynn,"85,292",TRUE
+Georgia,Gordon,3243,Gordon,"57,963",TRUE
+Georgia,Grady,970,Grady,"24,633",TRUE
+Georgia,Greene,699,Greene,"18,324",TRUE
+Georgia,Gwinnett,37236,Gwinnett,"936,250",TRUE
+Georgia,Habersham,2162,Habersham,"45,328",TRUE
+Georgia,Hall,12035,Hall,"204,441",TRUE
+Georgia,Hancock,466,Hancock,"8,457",TRUE
+Georgia,Haralson,1219,Haralson,"29,792",TRUE
+Georgia,Harris,992,Harris,"35,236",TRUE
+Georgia,Hart,759,Hart,"26,205",TRUE
+Georgia,Heard,347,Heard,"11,923",TRUE
+Georgia,Henry,8064,Henry,"234,561",TRUE
+Georgia,Houston,4544,Houston,"157,863",TRUE
+Georgia,Irwin,422,Irwin,"9,416",TRUE
+Georgia,Jackson,3119,Jackson,"72,977",TRUE
+Georgia,Jasper,435,Jasper,"14,219",TRUE
+Georgia,Jefferson,975,Jefferson,"15,362",TRUE
+Georgia,Jenkins,494,Jenkins,"8,676",TRUE
+Georgia,Johnson,521,Johnson,"9,643",TRUE
+Georgia,Jones,758,Jones,"28,735",TRUE
+Georgia,Lamar,632,Lamar,"19,077",TRUE
+Georgia,Lanier,387,Lanier,"10,423",TRUE
+Georgia,Laurens,2514,Laurens,"47,546",TRUE
+Georgia,Lee,907,Lee,"29,992",TRUE
+Georgia,Liberty,1491,Liberty,"61,435",TRUE
+Georgia,Lincoln,301,Lincoln,"7,921",TRUE
+Georgia,Long,319,Long,"19,559",TRUE
+Georgia,Lowndes,5989,Lowndes,"117,406",TRUE
+Georgia,Lumpkin,1229,Lumpkin,"33,610",TRUE
+Georgia,Meriwether,754,Meriwether,"21,167",TRUE
+Georgia,Miller,401,Miller,"5,718",TRUE
+Georgia,Mitchell,947,Mitchell,"21,863",TRUE
+Georgia,Monroe,994,Monroe,"27,578",TRUE
+Georgia,Montgomery,417,Montgomery,"9,172",TRUE
+Georgia,Morgan,786,Morgan,"19,276",TRUE
+Georgia,Murray,1569,Murray,"40,096",TRUE
+Georgia,Muscogee,7075,Muscogee,"195,769",TRUE
+Georgia,Newton,3617,Newton,"111,744",TRUE
+Georgia,Oconee,1296,Oconee,"40,280",TRUE
+Georgia,Oglethorpe,523,Oglethorpe,"15,259",TRUE
+Georgia,Paulding,4545,Paulding,"168,667",TRUE
+Georgia,Peach,1004,Peach,"27,546",TRUE
+Georgia,Pickens,1048,Pickens,"32,591",TRUE
+Georgia,Pierce,1186,Pierce,"19,465",TRUE
+Georgia,Pike,746,Pike,"18,962",TRUE
+Georgia,Polk,2247,Polk,"42,613",TRUE
+Georgia,Pulaski,435,Pulaski,"11,137",TRUE
+Georgia,Putnam,957,Putnam,"22,119",TRUE
+Georgia,Quitman,77,Quitman,"2,299",TRUE
+Georgia,Rabun,532,Rabun,"17,137",TRUE
+Georgia,Randolph,364,Randolph,"6,778",TRUE
+Georgia,Richmond,9737,Richmond,"202,518",TRUE
+Georgia,Rockdale,2572,Rockdale,"90,896",TRUE
+Georgia,Schley,156,Schley,"5,257",TRUE
+Georgia,Screven,495,Screven,"13,966",TRUE
+Georgia,Seminole,506,Seminole,"8,090",TRUE
+Georgia,Spalding,2203,Spalding,"66,703",TRUE
+Georgia,Stephens,1430,Stephens,"25,925",TRUE
+Georgia,Stewart,619,Stewart,"6,621",TRUE
+Georgia,Sumter,1193,Sumter,"29,524",TRUE
+Georgia,Talbot,224,Talbot,"6,195",TRUE
+Georgia,Taliaferro,37,Taliaferro,"1,537",TRUE
+Georgia,Tattnall,1058,Tattnall,"25,286",TRUE
+Georgia,Taylor,332,Taylor,"8,020",TRUE
+Georgia,Telfair,644,Telfair,"15,860",TRUE
+Georgia,Terrell,391,Terrell,"8,531",TRUE
+Georgia,Thomas,1864,Thomas,"44,451",TRUE
+Georgia,Tift,2356,Tift,"40,644",TRUE
+Georgia,Toombs,1662,Toombs,"26,830",TRUE
+Georgia,Towns,543,Towns,"12,037",TRUE
+Georgia,Treutlen,380,Treutlen,"6,901",TRUE
+Georgia,Troup,3797,Troup,"69,922",TRUE
+Georgia,Turner,425,Turner,"7,985",TRUE
+Georgia,Twiggs,249,Twiggs,"8,120",TRUE
+Georgia,Union,1035,Union,"24,511",TRUE
+Georgia,Upson,1454,Upson,"26,320",TRUE
+Georgia,Walker,2452,Walker,"69,761",TRUE
+Georgia,Walton,3031,Walton,"94,593",TRUE
+Georgia,Ware,2554,Ware,"35,734",TRUE
+Georgia,Warren,211,Warren,"5,254",TRUE
+Georgia,Washington,1049,Washington,"20,374",TRUE
+Georgia,Wayne,1541,Wayne,"29,927",TRUE
+Georgia,Webster,62,Webster,"2,607",TRUE
+Georgia,Wheeler,419,Wheeler,"7,855",TRUE
+Georgia,White,1207,White,"30,798",TRUE
+Georgia,Whitfield,7160,Whitfield,"104,628",TRUE
+Georgia,Wilcox,352,Wilcox,"8,635",TRUE
+Georgia,Wilkes,419,Wilkes,"9,777",TRUE
+Georgia,Wilkinson,423,Wilkinson,"8,954",TRUE
+Georgia,Worth,702,Worth,"20,247",TRUE
+Hawaii,Hawaii,1523,Hawaii,"201,513",TRUE
+Hawaii,Honolulu,14676,Honolulu,"974,563",TRUE
+Hawaii,Kalawao,0,Kalawao,86,TRUE
+Hawaii,Kauai,88,Kauai,"72,293",TRUE
+Hawaii,Maui,742,Maui,"167,417",TRUE
+Idaho,Ada,23065,Ada,"481,587",TRUE
+Idaho,Adams,88,Adams,"4,294",TRUE
+Idaho,Bannock,3792,Bannock,"87,808",TRUE
+Idaho,Benewah,234,Benewah,"9,298",TRUE
+Idaho,Bingham,2391,Bingham,"46,811",TRUE
+Idaho,Blaine,1181,Blaine,"23,021",TRUE
+Idaho,Boise,122,Boise,"7,831",TRUE
+Idaho,Bonner,839,Bonner,"45,739",TRUE
+Idaho,Bonneville,6626,Bonneville,"119,062",TRUE
+Idaho,Boundary,327,Boundary,"12,245",TRUE
+Idaho,Butte,117,Butte,"2,597",TRUE
+Idaho,Camas,51,Camas,"1,106",TRUE
+Idaho,Canyon,13482,Canyon,"229,849",TRUE
+Idaho,Caribou,409,Caribou,"7,155",TRUE
+Idaho,Cassia,1966,Cassia,"24,030",TRUE
+Idaho,Clark,48,Clark,845,TRUE
+Idaho,Clearwater,362,Clearwater,"8,756",TRUE
+Idaho,Custer,131,Custer,"4,315",TRUE
+Idaho,Elmore,806,Elmore,"27,511",TRUE
+Idaho,Franklin,563,Franklin,"13,876",TRUE
+Idaho,Fremont,643,Fremont,"13,099",TRUE
+Idaho,Gem,729,Gem,"18,112",TRUE
+Idaho,Gooding,885,Gooding,"15,179",TRUE
+Idaho,Idaho,659,Idaho,"16,667",TRUE
+Idaho,Jefferson,1383,Jefferson,"29,871",TRUE
+Idaho,Jerome,1748,Jerome,"24,412",TRUE
+Idaho,Kootenai,6514,Kootenai,"165,697",TRUE
+Idaho,Latah,1565,Latah,"40,108",TRUE
+Idaho,Lemhi,411,Lemhi,"8,027",TRUE
+Idaho,Lewis,172,Lewis,"3,838",TRUE
+Idaho,Lincoln,328,Lincoln,"5,366",TRUE
+Idaho,Madison,3697,Madison,"39,907",TRUE
+Idaho,Minidoka,1616,Minidoka,"21,039",TRUE
+Idaho,Oneida,117,Oneida,"4,531",TRUE
+Idaho,Owyhee,557,Owyhee,"11,823",TRUE
+Idaho,Payette,1453,Payette,"23,951",TRUE
+Idaho,Power,432,Power,"7,681",TRUE
+Idaho,Shoshone,452,Shoshone,"12,882",TRUE
+Idaho,Teton,474,Teton,"12,142",TRUE
+Idaho,Valley,210,Valley,"11,392",TRUE
+Idaho,Washington,659,Washington,"10,194",TRUE
+Illinois,Adams,4216,Adams,"65,435",TRUE
+Illinois,Alexander,233,Alexander,"5,761",TRUE
+Illinois,Bond,898,Bond,"16,426",TRUE
+Illinois,Boone,3425,Boone,"53,544",TRUE
+Illinois,Brown,266,Brown,"6,578",TRUE
+Illinois,Bureau,1862,Bureau,"32,628",TRUE
+Illinois,Calhoun,206,Calhoun,"4,739",TRUE
+Illinois,Carroll,959,Carroll,"14,305",TRUE
+Illinois,Cass,839,Cass,"12,147",TRUE
+Illinois,Champaign,9813,Champaign,"209,689",TRUE
+Illinois,Christian,1692,Christian,"32,304",TRUE
+Illinois,Clark,689,Clark,"15,441",TRUE
+Illinois,Clay,703,Clay,"13,184",TRUE
+Illinois,Clinton,2875,Clinton,"37,562",TRUE
+Illinois,Coles,3018,Coles,"50,621",TRUE
+Illinois,Cook,272733,Cook,"5,150,233",TRUE
+Illinois,Crawford,993,Crawford,"18,667",TRUE
+Illinois,Cumberland,538,Cumberland,"10,766",TRUE
+Illinois,Douglas,1224,Douglas,"19,465",TRUE
+Illinois,DuPage,39547,DuPage,"922,921",TRUE
+Illinois,Edgar,653,Edgar,"17,161",TRUE
+Illinois,Edwards,191,Edwards,"6,395",TRUE
+Illinois,Effingham,2324,Effingham,"34,008",TRUE
+Illinois,Fayette,1371,Fayette,"21,336",TRUE
+Illinois,Ford,631,Ford,"12,961",TRUE
+Illinois,Franklin,1798,Franklin,"38,469",TRUE
+Illinois,Fulton,1167,Fulton,"34,340",TRUE
+Illinois,Gallatin,173,Gallatin,"4,828",TRUE
+Illinois,Greene,724,Greene,"12,969",TRUE
+Illinois,Grundy,2321,Grundy,"51,054",TRUE
+Illinois,Hamilton,346,Hamilton,"8,116",TRUE
+Illinois,Hancock,849,Hancock,"17,708",TRUE
+Illinois,Hardin,111,Hardin,"3,821",TRUE
+Illinois,Henderson,243,Henderson,"6,646",TRUE
+Illinois,Henry,2177,Henry,"48,913",TRUE
+Illinois,Iroquois,1409,Iroquois,"27,114",TRUE
+Illinois,Jackson,2376,Jackson,"56,750",TRUE
+Illinois,Jasper,559,Jasper,"9,610",TRUE
+Illinois,Jefferson,1590,Jefferson,"37,684",TRUE
+Illinois,Jersey,1061,Jersey,"21,773",TRUE
+Illinois,Johnson,636,Johnson,"12,417",TRUE
+Illinois,Kane,28225,Kane,"532,403",TRUE
+Illinois,Kankakee,7363,Kankakee,"109,862",TRUE
+Illinois,Kendall,5443,Kendall,"128,990",TRUE
+Illinois,Knox,2384,Knox,"49,699",TRUE
+Illinois,Lawrence,788,Lawrence,"15,678",TRUE
+Illinois,Lee,1603,Lee,"34,096",TRUE
+Illinois,Livingston,1922,Livingston,"35,648",TRUE
+Illinois,Logan,1359,Logan,"28,618",TRUE
+Illinois,Menard,385,Menard,"12,196",TRUE
+Illinois,Mercer,638,Mercer,"15,437",TRUE
+Illinois,Monroe,1713,Monroe,"34,637",TRUE
+Illinois,Montgomery,1019,Montgomery,"28,414",TRUE
+Illinois,Morgan,1889,Morgan,"33,658",TRUE
+Illinois,Moultrie,789,Moultrie,"14,501",TRUE
+Illinois,Ogle,2468,Ogle,"50,643",TRUE
+Illinois,Peoria,7788,Peoria,"179,179",TRUE
+Illinois,Perry,882,Perry,"20,916",TRUE
+Illinois,Piatt,676,Piatt,"16,344",TRUE
+Illinois,Pike,907,Pike,"15,561",TRUE
+Illinois,Pope,66,Pope,"4,177",TRUE
+Illinois,Pulaski,353,Pulaski,"5,335",TRUE
+Illinois,Putnam,209,Putnam,"5,739",TRUE
+Illinois,Randolph,1951,Randolph,"31,782",TRUE
+Illinois,Richland,607,Richland,"15,513",TRUE
+Illinois,Stark,188,Stark,"5,342",TRUE
+Illinois,Stephenson,2206,Stephenson,"44,498",TRUE
+Illinois,Tazewell,5532,Tazewell,"131,803",TRUE
+Illinois,Union,1069,Union,"16,653",TRUE
+Illinois,Vermilion,3233,Vermilion,"75,758",TRUE
+Illinois,Wabash,434,Wabash,"11,520",TRUE
+Illinois,Warren,912,Warren,"16,844",TRUE
+Illinois,Washington,559,Washington,"13,887",TRUE
+Illinois,Wayne,779,Wayne,"16,215",TRUE
+Illinois,White,497,White,"13,537",TRUE
+Illinois,Whiteside,3293,Whiteside,"55,175",TRUE
+Illinois,Will,33564,Will,"690,743",TRUE
+Illinois,Williamson,3127,Williamson,"66,597",TRUE
+Illinois,Winnebago,16786,Winnebago,"282,572",TRUE
+Illinois,Woodford,1444,Woodford,"38,459",TRUE
+Indiana,Adams,1539,Adams,"35,777",TRUE
+Indiana,Allen,16218,Allen,"379,299",TRUE
+Indiana,Bartholomew,2789,Bartholomew,"83,779",TRUE
+Indiana,Benton,297,Benton,"8,748",TRUE
+Indiana,Blackford,474,Blackford,"11,758",TRUE
+Indiana,Boone,2201,Boone,"67,843",TRUE
+Indiana,Brown,302,Brown,"15,092",TRUE
+Indiana,Carroll,626,Carroll,"20,257",TRUE
+Indiana,Cass,2860,Cass,"37,689",TRUE
+Indiana,Clark,4631,Clark,"118,302",TRUE
+Indiana,Clay,997,Clay,"26,225",TRUE
+Indiana,Clinton,1635,Clinton,"32,399",TRUE
+Indiana,Crawford,257,Crawford,"10,577",TRUE
+Indiana,Daviess,1379,Daviess,"33,351",TRUE
+Indiana,Delaware,4570,Delaware,"114,135",TRUE
+Indiana,Dubois,2221,Dubois,"42,736",TRUE
+Indiana,Elkhart,15714,Elkhart,"206,341",TRUE
+Indiana,Fayette,1369,Fayette,"23,102",TRUE
+Indiana,Floyd,2878,Floyd,"78,522",TRUE
+Indiana,Fountain,693,Fountain,"16,346",TRUE
+Indiana,Franklin,601,Franklin,"22,758",TRUE
+Indiana,Fulton,762,Fulton,"19,974",TRUE
+Indiana,Gibson,1623,Gibson,"33,659",TRUE
+Indiana,Grant,2357,Grant,"65,769",TRUE
+Indiana,Greene,934,Greene,"31,922",TRUE
+Indiana,Hamilton,11585,Hamilton,"338,011",TRUE
+Indiana,Hancock,2270,Hancock,"78,168",TRUE
+Indiana,Harrison,1276,Harrison,"40,515",TRUE
+Indiana,Hendricks,5409,Hendricks,"170,311",TRUE
+Indiana,Henry,2256,Henry,"47,972",TRUE
+Indiana,Howard,3017,Howard,"82,544",TRUE
+Indiana,Huntington,1067,Huntington,"36,520",TRUE
+Indiana,Jackson,1916,Jackson,"44,231",TRUE
+Indiana,Jasper,1262,Jasper,"33,562",TRUE
+Indiana,Jay,875,Jay,"20,436",TRUE
+Indiana,Jefferson,1040,Jefferson,"32,308",TRUE
+Indiana,Jennings,758,Jennings,"27,735",TRUE
+Indiana,Johnson,5678,Johnson,"158,167",TRUE
+Indiana,Knox,1617,Knox,"36,594",TRUE
+Indiana,Kosciusko,4091,Kosciusko,"79,456",TRUE
+Indiana,LaGrange,1311,LaGrange,"39,614",TRUE
+Indiana,Lawrence,1640,Lawrence,"45,370",TRUE
+Indiana,Madison,4405,Madison,"129,569",TRUE
+Indiana,Marion,39125,Marion,"964,582",TRUE
+Indiana,Marshall,2760,Marshall,"46,258",TRUE
+Indiana,Martin,327,Martin,"10,255",TRUE
+Indiana,Miami,1404,Miami,"35,516",TRUE
+Indiana,Monroe,4964,Monroe,"148,431",TRUE
+Indiana,Montgomery,1226,Montgomery,"38,338",TRUE
+Indiana,Morgan,1872,Morgan,"70,489",TRUE
+Indiana,Newton,512,Newton,"13,984",TRUE
+Indiana,Noble,2318,Noble,"47,744",TRUE
+Indiana,Ohio,219,Ohio,"5,875",TRUE
+Indiana,Orange,630,Orange,"19,646",TRUE
+Indiana,Owen,522,Owen,"20,799",TRUE
+Indiana,Parke,484,Parke,"16,937",TRUE
+Indiana,Perry,786,Perry,"19,169",TRUE
+Indiana,Pike,482,Pike,"12,389",TRUE
+Indiana,Porter,7390,Porter,"170,389",TRUE
+Indiana,Posey,1131,Posey,"25,427",TRUE
+Indiana,Pulaski,351,Pulaski,"12,353",TRUE
+Indiana,Putnam,1104,Putnam,"37,576",TRUE
+Indiana,Randolph,1099,Randolph,"24,665",TRUE
+Indiana,Ripley,1144,Ripley,"28,324",TRUE
+Indiana,Rush,474,Rush,"16,581",TRUE
+Indiana,Starke,850,Starke,"22,995",TRUE
+Indiana,Steuben,1318,Steuben,"34,594",TRUE
+Indiana,Sullivan,791,Sullivan,"20,669",TRUE
+Indiana,Switzerland,237,Switzerland,"10,751",TRUE
+Indiana,Tippecanoe,7624,Tippecanoe,"195,732",TRUE
+Indiana,Tipton,503,Tipton,"15,148",TRUE
+Indiana,Union,248,Union,"7,054",TRUE
+Indiana,Vanderburgh,8945,Vanderburgh,"181,451",TRUE
+Indiana,Vermillion,521,Vermillion,"15,498",TRUE
+Indiana,Vigo,5419,Vigo,"107,038",TRUE
+Indiana,Wabash,1365,Wabash,"30,996",TRUE
+Indiana,Warren,216,Warren,"8,265",TRUE
+Indiana,Warrick,3002,Warrick,"62,998",TRUE
+Indiana,Washington,646,Washington,"28,036",TRUE
+Indiana,Wayne,2771,Wayne,"65,884",TRUE
+Indiana,Wells,1100,Wells,"28,296",TRUE
+Indiana,White,1095,White,"24,102",TRUE
+Indiana,Whitley,1195,Whitley,"33,964",TRUE
+Iowa,Adair,396,Adair,"7,152",TRUE
+Iowa,Adams,150,Adams,"3,602",TRUE
+Iowa,Allamakee,688,Allamakee,"13,687",TRUE
+Iowa,Appanoose,692,Appanoose,"12,426",TRUE
+Iowa,Audubon,279,Audubon,"5,496",TRUE
+Iowa,Benton,1518,Benton,"25,645",TRUE
+Iowa,Boone,1241,Boone,"26,234",TRUE
+Iowa,Bremer,1711,Bremer,"25,062",TRUE
+Iowa,Buchanan,1047,Buchanan,"21,175",TRUE
+Iowa,Butler,871,Butler,"14,439",TRUE
+Iowa,Calhoun,970,Calhoun,"9,668",TRUE
+Iowa,Carroll,1837,Carroll,"20,165",TRUE
+Iowa,Cass,717,Cass,"12,836",TRUE
+Iowa,Cedar,948,Cedar,"18,627",TRUE
+Iowa,Cherokee,721,Cherokee,"11,235",TRUE
+Iowa,Chickasaw,747,Chickasaw,"11,933",TRUE
+Iowa,Clarke,452,Clarke,"9,395",TRUE
+Iowa,Clay,1006,Clay,"16,016",TRUE
+Iowa,Clayton,971,Clayton,"17,549",TRUE
+Iowa,Clinton,2927,Clinton,"46,429",TRUE
+Iowa,Crawford,1660,Crawford,"16,820",TRUE
+Iowa,Dallas,5792,Dallas,"93,453",TRUE
+Iowa,Davis,418,Davis,"9,000",TRUE
+Iowa,Decatur,293,Decatur,"7,870",TRUE
+Iowa,Delaware,1318,Delaware,"17,011",TRUE
+Iowa,Dickinson,1232,Dickinson,"17,258",TRUE
+Iowa,Dubuque,8475,Dubuque,"97,311",TRUE
+Iowa,Emmet,688,Emmet,"9,208",TRUE
+Iowa,Fayette,927,Fayette,"19,650",TRUE
+Iowa,Floyd,895,Floyd,"15,642",TRUE
+Iowa,Franklin,662,Franklin,"10,070",TRUE
+Iowa,Fremont,334,Fremont,"6,960",TRUE
+Iowa,Greene,473,Greene,"8,888",TRUE
+Iowa,Grundy,750,Grundy,"12,232",TRUE
+Iowa,Guthrie,682,Guthrie,"10,689",TRUE
+Iowa,Hamilton,957,Hamilton,"14,773",TRUE
+Iowa,Hancock,773,Hancock,"10,630",TRUE
+Iowa,Hardin,1019,Hardin,"16,846",TRUE
+Iowa,Harrison,991,Harrison,"14,049",TRUE
+Iowa,Henry,1661,Henry,"19,954",TRUE
+Iowa,Howard,475,Howard,"9,158",TRUE
+Iowa,Humboldt,640,Humboldt,"9,558",TRUE
+Iowa,Ida,423,Ida,"6,860",TRUE
+Iowa,Iowa,842,Iowa,"16,184",TRUE
+Iowa,Jackson,1308,Jackson,"19,439",TRUE
+Iowa,Jasper,1981,Jasper,"37,185",TRUE
+Iowa,Jefferson,590,Jefferson,"18,295",TRUE
+Iowa,Johnson,8818,Johnson,"151,140",TRUE
+Iowa,Jones,2164,Jones,"20,681",TRUE
+Iowa,Keokuk,507,Keokuk,"10,246",TRUE
+Iowa,Kossuth,896,Kossuth,"14,813",TRUE
+Iowa,Lee,1826,Lee,"33,657",TRUE
+Iowa,Linn,12843,Linn,"226,706",TRUE
+Iowa,Louisa,775,Louisa,"11,035",TRUE
+Iowa,Lucas,297,Lucas,"8,600",TRUE
+Iowa,Lyon,920,Lyon,"11,755",TRUE
+Iowa,Madison,622,Madison,"16,338",TRUE
+Iowa,Mahaska,1159,Mahaska,"22,095",TRUE
+Iowa,Marion,1860,Marion,"33,253",TRUE
+Iowa,Marshall,3211,Marshall,"39,369",TRUE
+Iowa,Mills,943,Mills,"15,109",TRUE
+Iowa,Mitchell,684,Mitchell,"10,586",TRUE
+Iowa,Monona,366,Monona,"8,615",TRUE
+Iowa,Monroe,404,Monroe,"7,707",TRUE
+Iowa,Montgomery,403,Montgomery,"9,917",TRUE
+Iowa,Muscatine,2575,Muscatine,"42,664",TRUE
+Iowa,Osceola,480,Osceola,"5,958",TRUE
+Iowa,Page,1055,Page,"15,107",TRUE
+Iowa,Plymouth,2544,Plymouth,"25,177",TRUE
+Iowa,Pocahontas,495,Pocahontas,"6,619",TRUE
+Iowa,Polk,30369,Polk,"490,161",TRUE
+Iowa,Pottawattamie,5544,Pottawattamie,"93,206",TRUE
+Iowa,Poweshiek,886,Poweshiek,"18,504",TRUE
+Iowa,Ringgold,172,Ringgold,"4,894",TRUE
+Iowa,Sac,752,Sac,"9,721",TRUE
+Iowa,Scott,9830,Scott,"172,943",TRUE
+Iowa,Shelby,705,Shelby,"11,454",TRUE
+Iowa,Sioux,3433,Sioux,"34,855",TRUE
+Iowa,Story,6170,Story,"97,117",TRUE
+Iowa,Tama,1432,Tama,"16,854",TRUE
+Iowa,Taylor,404,Taylor,"6,121",TRUE
+Iowa,Union,656,Union,"12,241",TRUE
+Iowa,Wapello,2327,Wapello,"34,969",TRUE
+Iowa,Warren,2453,Warren,"51,466",TRUE
+Iowa,Washington,1234,Washington,"21,965",TRUE
+Iowa,Wayne,279,Wayne,"6,441",TRUE
+Iowa,Webster,3245,Webster,"35,904",TRUE
+Iowa,Winnebago,855,Winnebago,"10,354",TRUE
+Iowa,Winneshiek,860,Winneshiek,"19,991",TRUE
+Iowa,Woodbury,9706,Woodbury,"103,107",TRUE
+Iowa,Worth,318,Worth,"7,381",TRUE
+Iowa,Wright,1118,Wright,"12,562",TRUE
+Kansas,Allen,298,Allen,"12,369",TRUE
+Kansas,Anderson,343,Anderson,"7,858",TRUE
+Kansas,Atchison,777,Atchison,"16,073",TRUE
+Kansas,Barber,171,Barber,"4,427",TRUE
+Kansas,Barton,1455,Barton,"25,779",TRUE
+Kansas,Bourbon,463,Bourbon,"14,534",TRUE
+Kansas,Brown,606,Brown,"9,564",TRUE
+Kansas,Butler,2790,Butler,"66,911",TRUE
+Kansas,Chase,145,Chase,"2,648",TRUE
+Kansas,Chautauqua,63,Chautauqua,"3,250",TRUE
+Kansas,Cherokee,1023,Cherokee,"19,939",TRUE
+Kansas,Cheyenne,199,Cheyenne,"2,657",TRUE
+Kansas,Clark,100,Clark,"1,994",TRUE
+Kansas,Clay,410,Clay,"8,002",TRUE
+Kansas,Cloud,498,Cloud,"8,786",TRUE
+Kansas,Coffey,273,Coffey,"8,179",TRUE
+Kansas,Comanche,44,Comanche,"1,700",TRUE
+Kansas,Cowley,1267,Cowley,"34,908",TRUE
+Kansas,Crawford,2103,Crawford,"38,818",TRUE
+Kansas,Decatur,189,Decatur,"2,827",TRUE
+Kansas,Dickinson,645,Dickinson,"18,466",TRUE
+Kansas,Doniphan,391,Doniphan,"7,600",TRUE
+Kansas,Douglas,4226,Douglas,"122,259",TRUE
+Kansas,Edwards,156,Edwards,"2,798",TRUE
+Kansas,Elk,42,Elk,"2,530",TRUE
+Kansas,Ellis,2129,Ellis,"28,553",TRUE
+Kansas,Ellsworth,539,Ellsworth,"6,102",TRUE
+Kansas,Finney,4413,Finney,"36,467",TRUE
+Kansas,Ford,4421,Ford,"33,619",TRUE
+Kansas,Franklin,947,Franklin,"25,544",TRUE
+Kansas,Geary,773,Geary,"31,670",TRUE
+Kansas,Gove,272,Gove,"2,636",TRUE
+Kansas,Graham,125,Graham,"2,482",TRUE
+Kansas,Grant,649,Grant,"7,150",TRUE
+Kansas,Gray,383,Gray,"5,988",TRUE
+Kansas,Greeley,83,Greeley,"1,232",TRUE
+Kansas,Greenwood,161,Greenwood,"5,982",TRUE
+Kansas,Hamilton,128,Hamilton,"2,539",TRUE
+Kansas,Harper,275,Harper,"5,436",TRUE
+Kansas,Harvey,1553,Harvey,"34,429",TRUE
+Kansas,Haskell,235,Haskell,"3,968",TRUE
+Kansas,Hodgeman,124,Hodgeman,"1,794",TRUE
+Kansas,Jackson,573,Jackson,"13,171",TRUE
+Kansas,Jefferson,601,Jefferson,"19,043",TRUE
+Kansas,Jewell,51,Jewell,"2,879",TRUE
+Kansas,Johnson,23891,Johnson,"602,401",TRUE
+Kansas,Kearny,304,Kearny,"3,838",TRUE
+Kansas,Kingman,302,Kingman,"7,152",TRUE
+Kansas,Kiowa,100,Kiowa,"2,475",TRUE
+Kansas,Labette,734,Labette,"19,618",TRUE
+Kansas,Lane,67,Lane,"1,535",TRUE
+Kansas,Leavenworth,3408,Leavenworth,"81,758",TRUE
+Kansas,Lincoln,52,Lincoln,"2,962",TRUE
+Kansas,Linn,248,Linn,"9,703",TRUE
+Kansas,Logan,207,Logan,"2,794",TRUE
+Kansas,Lyon,2230,Lyon,"33,195",TRUE
+Kansas,Meade,280,Meade,"4,033",TRUE
+Kansas,Miami,866,Miami,"34,237",TRUE
+Kansas,Mitchell,179,Mitchell,"5,979",TRUE
+Kansas,Montgomery,969,Montgomery,"31,829",TRUE
+Kansas,Morris,145,Morris,"5,620",TRUE
+Kansas,Morton,137,Morton,"2,587",TRUE
+Kansas,Nemaha,873,Nemaha,"10,231",TRUE
+Kansas,Neosho,592,Neosho,"16,007",TRUE
+Kansas,Ness,231,Ness,"2,750",TRUE
+Kansas,Norton,1040,Norton,"5,361",TRUE
+Kansas,Osage,425,Osage,"15,949",TRUE
+Kansas,Osborne,66,Osborne,"3,421",TRUE
+Kansas,Ottawa,192,Ottawa,"5,704",TRUE
+Kansas,Pawnee,591,Pawnee,"6,414",TRUE
+Kansas,Phillips,356,Phillips,"5,234",TRUE
+Kansas,Pottawatomie,613,Pottawatomie,"24,383",TRUE
+Kansas,Pratt,437,Pratt,"9,164",TRUE
+Kansas,Rawlins,160,Rawlins,"2,530",TRUE
+Kansas,Reno,4125,Reno,"61,998",TRUE
+Kansas,Republic,244,Republic,"4,636",TRUE
+Kansas,Rice,333,Rice,"9,537",TRUE
+Kansas,Riley,3157,Riley,"74,232",TRUE
+Kansas,Rooks,284,Rooks,"4,920",TRUE
+Kansas,Rush,181,Rush,"3,036",TRUE
+Kansas,Russell,460,Russell,"6,856",TRUE
+Kansas,Saline,2002,Saline,"54,224",TRUE
+Kansas,Scott,318,Scott,"4,823",TRUE
+Kansas,Sedgwick,23476,Sedgwick,"516,042",TRUE
+Kansas,Seward,2628,Seward,"21,428",TRUE
+Kansas,Shawnee,6381,Shawnee,"176,875",TRUE
+Kansas,Sheridan,288,Sheridan,"2,521",TRUE
+Kansas,Sherman,394,Sherman,"5,917",TRUE
+Kansas,Smith,108,Smith,"3,583",TRUE
+Kansas,Stafford,177,Stafford,"4,156",TRUE
+Kansas,Stanton,132,Stanton,"2,006",TRUE
+Kansas,Stevens,395,Stevens,"5,485",TRUE
+Kansas,Sumner,658,Sumner,"22,836",TRUE
+Kansas,Thomas,597,Thomas,"7,777",TRUE
+Kansas,Trego,192,Trego,"2,803",TRUE
+Kansas,Wabaunsee,278,Wabaunsee,"6,931",TRUE
+Kansas,Wallace,133,Wallace,"1,518",TRUE
+Kansas,Washington,264,Washington,"5,406",TRUE
+Kansas,Wichita,124,Wichita,"2,119",TRUE
+Kansas,Wilson,242,Wilson,"8,525",TRUE
+Kansas,Woodson,56,Woodson,"3,138",TRUE
+Kansas,Wyandotte,10535,Wyandotte,"165,429",TRUE
+Kentucky,Adair,673,Adair,"19,202",TRUE
+Kentucky,Allen,658,Allen,"21,315",TRUE
+Kentucky,Anderson,435,Anderson,"22,747",TRUE
+Kentucky,Ballard,122,Ballard,"7,888",TRUE
+Kentucky,Barren,1788,Barren,"44,249",TRUE
+Kentucky,Bath,219,Bath,"12,500",TRUE
+Kentucky,Bell,1138,Bell,"26,032",TRUE
+Kentucky,Boone,3780,Boone,"133,581",TRUE
+Kentucky,Bourbon,480,Bourbon,"19,788",TRUE
+Kentucky,Boyd,1299,Boyd,"46,718",TRUE
+Kentucky,Boyle,773,Boyle,"30,060",TRUE
+Kentucky,Bracken,117,Bracken,"8,303",TRUE
+Kentucky,Breathitt,284,Breathitt,"12,630",TRUE
+Kentucky,Breckinridge,404,Breckinridge,"20,477",TRUE
+Kentucky,Bullitt,2458,Bullitt,"81,676",TRUE
+Kentucky,Butler,494,Butler,"12,879",TRUE
+Kentucky,Caldwell,478,Caldwell,"12,747",TRUE
+Kentucky,Calloway,1479,Calloway,"39,001",TRUE
+Kentucky,Campbell,2386,Campbell,"93,584",TRUE
+Kentucky,Carlisle,170,Carlisle,"4,760",TRUE
+Kentucky,Carroll,293,Carroll,"10,631",TRUE
+Kentucky,Carter,584,Carter,"26,797",TRUE
+Kentucky,Casey,453,Casey,"16,159",TRUE
+Kentucky,Christian,2626,Christian,"70,461",TRUE
+Kentucky,Clark,763,Clark,"36,263",TRUE
+Kentucky,Clay,906,Clay,"19,901",TRUE
+Kentucky,Clinton,348,Clinton,"10,218",TRUE
+Kentucky,Crittenden,215,Crittenden,"8,806",TRUE
+Kentucky,Cumberland,202,Cumberland,"6,614",TRUE
+Kentucky,Daviess,2993,Daviess,"101,511",TRUE
+Kentucky,Edmonson,315,Edmonson,"12,150",TRUE
+Kentucky,Elliott,551,Elliott,"7,517",TRUE
+Kentucky,Estill,399,Estill,"14,106",TRUE
+Kentucky,Fayette,14967,Fayette,"323,152",TRUE
+Kentucky,Fleming,277,Fleming,"14,581",TRUE
+Kentucky,Floyd,991,Floyd,"35,589",TRUE
+Kentucky,Franklin,1220,Franklin,"50,991",TRUE
+Kentucky,Fulton,271,Fulton,"5,969",TRUE
+Kentucky,Gallatin,178,Gallatin,"8,869",TRUE
+Kentucky,Garrard,485,Garrard,"17,666",TRUE
+Kentucky,Grant,525,Grant,"25,069",TRUE
+Kentucky,Graves,1504,Graves,"37,266",TRUE
+Kentucky,Grayson,810,Grayson,"26,427",TRUE
+Kentucky,Green,435,Green,"10,941",TRUE
+Kentucky,Greenup,1058,Greenup,"35,098",TRUE
+Kentucky,Hancock,270,Hancock,"8,722",TRUE
+Kentucky,Hardin,3594,Hardin,"110,958",TRUE
+Kentucky,Harlan,791,Harlan,"26,010",TRUE
+Kentucky,Harrison,397,Harrison,"18,886",TRUE
+Kentucky,Hart,669,Hart,"19,035",TRUE
+Kentucky,Henderson,1829,Henderson,"45,210",TRUE
+Kentucky,Henry,437,Henry,"16,126",TRUE
+Kentucky,Hickman,138,Hickman,"4,380",TRUE
+Kentucky,Hopkins,1600,Hopkins,"44,686",TRUE
+Kentucky,Jackson,611,Jackson,"13,329",TRUE
+Kentucky,Jefferson,32073,Jefferson,"766,757",TRUE
+Kentucky,Jessamine,1506,Jessamine,"54,115",TRUE
+Kentucky,Johnson,642,Johnson,"22,188",TRUE
+Kentucky,Kenton,4542,Kenton,"166,998",TRUE
+Kentucky,Knott,498,Knott,"14,806",TRUE
+Kentucky,Knox,1106,Knox,"31,145",TRUE
+Kentucky,Larue,487,Larue,"14,398",TRUE
+Kentucky,Laurel,2206,Laurel,"60,813",TRUE
+Kentucky,Lawrence,331,Lawrence,"15,317",TRUE
+Kentucky,Lee,771,Lee,"7,403",TRUE
+Kentucky,Leslie,190,Leslie,"9,877",TRUE
+Kentucky,Letcher,443,Letcher,"21,553",TRUE
+Kentucky,Lewis,438,Lewis,"13,275",TRUE
+Kentucky,Lincoln,542,Lincoln,"24,549",TRUE
+Kentucky,Livingston,238,Livingston,"9,194",TRUE
+Kentucky,Logan,1081,Logan,"27,102",TRUE
+Kentucky,Lyon,171,Lyon,"8,210",TRUE
+Kentucky,Meade,596,Meade,"28,572",TRUE
+Kentucky,Menifee,112,Menifee,"6,489",TRUE
+Kentucky,Mercer,578,Mercer,"21,933",TRUE
+Kentucky,Metcalfe,338,Metcalfe,"10,071",TRUE
+Kentucky,Monroe,644,Monroe,"10,650",TRUE
+Kentucky,Montgomery,789,Montgomery,"28,157",TRUE
+Kentucky,Morgan,256,Morgan,"13,309",TRUE
+Kentucky,Muhlenberg,1244,Muhlenberg,"30,622",TRUE
+Kentucky,Nelson,1840,Nelson,"46,233",TRUE
+Kentucky,Nicholas,151,Nicholas,"7,269",TRUE
+Kentucky,Ohio,824,Ohio,"23,994",TRUE
+Kentucky,Oldham,1964,Oldham,"66,799",TRUE
+Kentucky,Owen,168,Owen,"10,901",TRUE
+Kentucky,Owsley,170,Owsley,"4,415",TRUE
+Kentucky,Pendleton,273,Pendleton,"14,590",TRUE
+Kentucky,Perry,839,Perry,"25,758",TRUE
+Kentucky,Pike,1590,Pike,"57,876",TRUE
+Kentucky,Powell,392,Powell,"12,359",TRUE
+Kentucky,Pulaski,1371,Pulaski,"64,979",TRUE
+Kentucky,Robertson,66,Robertson,"2,108",TRUE
+Kentucky,Rockcastle,457,Rockcastle,"16,695",TRUE
+Kentucky,Rowan,648,Rowan,"24,460",TRUE
+Kentucky,Russell,512,Russell,"17,923",TRUE
+Kentucky,Scott,1525,Scott,"57,004",TRUE
+Kentucky,Shelby,1989,Shelby,"49,024",TRUE
+Kentucky,Simpson,524,Simpson,"18,572",TRUE
+Kentucky,Spencer,538,Spencer,"19,351",TRUE
+Kentucky,Taylor,794,Taylor,"25,769",TRUE
+Kentucky,Todd,372,Todd,"12,294",TRUE
+Kentucky,Trigg,351,Trigg,"14,651",TRUE
+Kentucky,Trimble,142,Trimble,"8,471",TRUE
+Kentucky,Union,668,Union,"14,381",TRUE
+Kentucky,Warren,6586,Warren,"132,896",TRUE
+Kentucky,Washington,435,Washington,"12,095",TRUE
+Kentucky,Wayne,446,Wayne,"20,333",TRUE
+Kentucky,Webster,511,Webster,"12,942",TRUE
+Kentucky,Whitley,1319,Whitley,"36,264",TRUE
+Kentucky,Wolfe,149,Wolfe,"7,157",TRUE
+Kentucky,Woodford,632,Woodford,"26,734",TRUE
+Maine,Androscoggin,1309,Androscoggin,"108,277",TRUE
+Maine,Aroostook,91,Aroostook,"67,055",TRUE
+Maine,Cumberland,3458,Cumberland,"295,003",TRUE
+Maine,Franklin,187,Franklin,"30,199",TRUE
+Maine,Hancock,201,Hancock,"54,987",TRUE
+Maine,Kennebec,639,Kennebec,"122,302",TRUE
+Maine,Knox,179,Knox,"39,772",TRUE
+Maine,Lincoln,131,Lincoln,"34,634",TRUE
+Maine,Oxford,277,Oxford,"57,975",TRUE
+Maine,Penobscot,598,Penobscot,"152,148",TRUE
+Maine,Piscataquis,32,Piscataquis,"16,785",TRUE
+Maine,Sagadahoc,127,Sagadahoc,"35,856",TRUE
+Maine,Somerset,387,Somerset,"50,484",TRUE
+Maine,Waldo,202,Waldo,"39,715",TRUE
+Maine,Washington,172,Washington,"31,379",TRUE
+Maine,York,1965,York,"207,641",TRUE
+Maryland,Allegany,2115,Allegany,"70,416",TRUE
+Maryland,Baltimore,26088,Baltimore,"827,370",TRUE
+Maryland,Calvert,1439,Calvert,"92,525",TRUE
+Maryland,Caroline,844,Caroline,"33,406",TRUE
+Maryland,Carroll,2930,Carroll,"168,447",TRUE
+Maryland,Cecil,1795,Cecil,"102,855",TRUE
+Maryland,Charles,3938,Charles,"163,257",TRUE
+Maryland,Dorchester,932,Dorchester,"31,929",TRUE
+Maryland,Frederick,5943,Frederick,"259,547",TRUE
+Maryland,Garrett,447,Garrett,"29,014",TRUE
+Maryland,Harford,5184,Harford,"255,441",TRUE
+Maryland,Howard,7201,Howard,"325,690",TRUE
+Maryland,Kent,391,Kent,"19,422",TRUE
+Maryland,Montgomery,30580,Montgomery,"1,050,688",TRUE
+Maryland,Talbot,733,Talbot,"37,181",TRUE
+Maryland,Washington,3409,Washington,"151,049",TRUE
+Maryland,Wicomico,3071,Wicomico,"103,609",TRUE
+Maryland,Worcester,1403,Worcester,"52,276",TRUE
+Massachusetts,Barnstable,2488,Barnstable,"212,990",TRUE
+Massachusetts,Berkshire,1201,Berkshire,"124,944",TRUE
+Massachusetts,Bristol,17337,Bristol,"565,217",TRUE
+Massachusetts,Essex,30674,Essex,"789,034",TRUE
+Massachusetts,Franklin,571,Franklin,"70,180",TRUE
+Massachusetts,Hampden,13929,Hampden,"466,372",TRUE
+Massachusetts,Hampshire,2037,Hampshire,"160,830",TRUE
+Massachusetts,Middlesex,40680,Middlesex,"1,611,699",TRUE
+Massachusetts,Norfolk,14569,Norfolk,"706,775",TRUE
+Massachusetts,Plymouth,13505,Plymouth,"521,202",TRUE
+Massachusetts,Suffolk,34270,Suffolk,"803,907",TRUE
+Massachusetts,Worcester,22038,Worcester,"830,622",TRUE
+Michigan,Alcona,124,Alcona,"10,405",TRUE
+Michigan,Alger,200,Alger,"9,108",TRUE
+Michigan,Allegan,3212,Allegan,"118,081",TRUE
+Michigan,Alpena,432,Alpena,"28,405",TRUE
+Michigan,Antrim,313,Antrim,"23,324",TRUE
+Michigan,Arenac,297,Arenac,"14,883",TRUE
+Michigan,Baraga,385,Baraga,"8,209",TRUE
+Michigan,Barry,1652,Barry,"61,550",TRUE
+Michigan,Bay,3500,Bay,"103,126",TRUE
+Michigan,Benzie,275,Benzie,"17,766",TRUE
+Michigan,Berrien,5336,Berrien,"153,401",TRUE
+Michigan,Branch,1898,Branch,"43,517",TRUE
+Michigan,Calhoun,5263,Calhoun,"134,159",TRUE
+Michigan,Cass,1865,Cass,"51,787",TRUE
+Michigan,Charlevoix,443,Charlevoix,"26,143",TRUE
+Michigan,Cheboygan,384,Cheboygan,"25,276",TRUE
+Michigan,Chippewa,637,Chippewa,"37,349",TRUE
+Michigan,Clare,610,Clare,"30,950",TRUE
+Michigan,Clinton,2341,Clinton,"79,595",TRUE
+Michigan,Crawford,275,Crawford,"14,029",TRUE
+Michigan,Delta,2261,Delta,"35,784",TRUE
+Michigan,Dickinson,1475,Dickinson,"25,239",TRUE
+Michigan,Eaton,2510,Eaton,"110,268",TRUE
+Michigan,Emmet,823,Emmet,"33,415",TRUE
+Michigan,Genesee,12199,Genesee,"405,813",TRUE
+Michigan,Gladwin,626,Gladwin,"25,449",TRUE
+Michigan,Gogebic,689,Gogebic,"13,975",TRUE
+Michigan,Gratiot,1595,Gratiot,"40,711",TRUE
+Michigan,Hillsdale,1298,Hillsdale,"45,605",TRUE
+Michigan,Houghton,1411,Houghton,"35,684",TRUE
+Michigan,Huron,575,Huron,"30,981",TRUE
+Michigan,Ingham,7598,Ingham,"292,406",TRUE
+Michigan,Ionia,1843,Ionia,"64,697",TRUE
+Michigan,Iosco,582,Iosco,"25,127",TRUE
+Michigan,Iron,659,Iron,"11,066",TRUE
+Michigan,Isabella,2060,Isabella,"69,872",TRUE
+Michigan,Jackson,3992,Jackson,"158,510",TRUE
+Michigan,Kalamazoo,8175,Kalamazoo,"265,066",TRUE
+Michigan,Kalkaska,287,Kalkaska,"18,038",TRUE
+Michigan,Kent,27706,Kent,"656,955",TRUE
+Michigan,Keweenaw,60,Keweenaw,"2,116",TRUE
+Michigan,Lake,160,Lake,"11,853",TRUE
+Michigan,Lapeer,1871,Lapeer,"87,607",TRUE
+Michigan,Leelanau,305,Leelanau,"21,761",TRUE
+Michigan,Lenawee,2051,Lenawee,"98,451",TRUE
+Michigan,Livingston,4344,Livingston,"191,995",TRUE
+Michigan,Luce,153,Luce,"6,229",TRUE
+Michigan,Mackinac,239,Mackinac,"10,799",TRUE
+Michigan,Macomb,31164,Macomb,"873,972",TRUE
+Michigan,Manistee,297,Manistee,"24,558",TRUE
+Michigan,Marquette,2463,Marquette,"66,699",TRUE
+Michigan,Mason,498,Mason,"29,144",TRUE
+Michigan,Mecosta,1013,Mecosta,"43,453",TRUE
+Michigan,Menominee,1151,Menominee,"22,780",TRUE
+Michigan,Midland,2500,Midland,"83,156",TRUE
+Michigan,Missaukee,231,Missaukee,"15,118",TRUE
+Michigan,Monroe,4217,Monroe,"150,500",TRUE
+Michigan,Montcalm,1500,Montcalm,"63,888",TRUE
+Michigan,Montmorency,112,Montmorency,"9,328",TRUE
+Michigan,Muskegon,6028,Muskegon,"173,566",TRUE
+Michigan,Newaygo,1286,Newaygo,"48,980",TRUE
+Michigan,Oakland,39629,Oakland,"1,257,584",TRUE
+Michigan,Oceana,1025,Oceana,"26,467",TRUE
+Michigan,Ogemaw,383,Ogemaw,"20,997",TRUE
+Michigan,Ontonagon,254,Ontonagon,"5,720",TRUE
+Michigan,Osceola,403,Osceola,"23,460",TRUE
+Michigan,Oscoda,113,Oscoda,"8,241",TRUE
+Michigan,Otsego,620,Otsego,"24,668",TRUE
+Michigan,Ottawa,11264,Ottawa,"291,830",TRUE
+Michigan,Roscommon,465,Roscommon,"24,019",TRUE
+Michigan,Saginaw,7198,Saginaw,"190,539",TRUE
+Michigan,Tuscola,1394,Tuscola,"52,245",TRUE
+Michigan,Washtenaw,8492,Washtenaw,"367,601",TRUE
+Michigan,Wayne,56100,Wayne,"1,749,343",TRUE
+Michigan,Wexford,460,Wexford,"33,631",TRUE
+Minnesota,Aitkin,594,Aitkin,"15,886",TRUE
+Minnesota,Anoka,18296,Anoka,"356,921",TRUE
+Minnesota,Becker,1557,Becker,"34,423",TRUE
+Minnesota,Beltrami,1696,Beltrami,"47,188",TRUE
+Minnesota,Benton,2449,Benton,"40,889",TRUE
+Minnesota,Brown,1024,Brown,"25,008",TRUE
+Minnesota,Carlton,1350,Carlton,"35,871",TRUE
+Minnesota,Carver,3714,Carver,"105,089",TRUE
+Minnesota,Cass,1094,Cass,"29,779",TRUE
+Minnesota,Chippewa,704,Chippewa,"11,800",TRUE
+Minnesota,Chisago,2624,Chisago,"56,579",TRUE
+Minnesota,Clay,4144,Clay,"64,222",TRUE
+Minnesota,Clearwater,396,Clearwater,"8,818",TRUE
+Minnesota,Cook,54,Cook,"5,463",TRUE
+Minnesota,Cottonwood,601,Cottonwood,"11,196",TRUE
+Minnesota,Dakota,17787,Dakota,"429,021",TRUE
+Minnesota,Dodge,741,Dodge,"20,934",TRUE
+Minnesota,Douglas,1964,Douglas,"38,141",TRUE
+Minnesota,Faribault,444,Faribault,"13,653",TRUE
+Minnesota,Fillmore,557,Fillmore,"21,067",TRUE
+Minnesota,Freeborn,1279,Freeborn,"30,281",TRUE
+Minnesota,Goodhue,1623,Goodhue,"46,340",TRUE
+Minnesota,Grant,205,Grant,"5,972",TRUE
+Minnesota,Hennepin,55721,Hennepin,"1,265,843",TRUE
+Minnesota,Houston,567,Houston,"18,600",TRUE
+Minnesota,Hubbard,867,Hubbard,"21,491",TRUE
+Minnesota,Isanti,1502,Isanti,"40,596",TRUE
+Minnesota,Itasca,1566,Itasca,"45,130",TRUE
+Minnesota,Jackson,373,Jackson,"9,846",TRUE
+Minnesota,Kanabec,475,Kanabec,"16,337",TRUE
+Minnesota,Kandiyohi,3177,Kandiyohi,"43,199",TRUE
+Minnesota,Kittson,157,Kittson,"4,298",TRUE
+Minnesota,Koochiching,308,Koochiching,"12,229",TRUE
+Minnesota,Lake,304,Lake,"10,641",TRUE
+Minnesota,Lincoln,286,Lincoln,"5,639",TRUE
+Minnesota,Lyon,1747,Lyon,"25,474",TRUE
+Minnesota,Mahnomen,219,Mahnomen,"5,527",TRUE
+Minnesota,Marshall,375,Marshall,"9,336",TRUE
+Minnesota,Martin,913,Martin,"19,683",TRUE
+Minnesota,McLeod,1634,McLeod,"35,893",TRUE
+Minnesota,Meeker,926,Meeker,"23,222",TRUE
+Minnesota,Morrison,1934,Morrison,"33,386",TRUE
+Minnesota,Mower,2228,Mower,"40,062",TRUE
+Minnesota,Murray,496,Murray,"8,194",TRUE
+Minnesota,Nicollet,1361,Nicollet,"34,274",TRUE
+Minnesota,Nobles,2887,Nobles,"21,629",TRUE
+Minnesota,Norman,285,Norman,"6,375",TRUE
+Minnesota,Olmsted,5800,Olmsted,"158,293",TRUE
+Minnesota,Pennington,466,Pennington,"14,119",TRUE
+Minnesota,Pine,1055,Pine,"29,579",TRUE
+Minnesota,Pipestone,612,Pipestone,"9,126",TRUE
+Minnesota,Polk,2021,Polk,"31,364",TRUE
+Minnesota,Pope,434,Pope,"11,249",TRUE
+Minnesota,Ramsey,23623,Ramsey,"550,321",TRUE
+Minnesota,Redwood,687,Redwood,"15,170",TRUE
+Minnesota,Renville,620,Renville,"14,548",TRUE
+Minnesota,Rice,3358,Rice,"66,972",TRUE
+Minnesota,Rock,583,Rock,"9,315",TRUE
+Minnesota,Roseau,874,Roseau,"15,165",TRUE
+Minnesota,Stearns,11593,Stearns,"161,075",TRUE
+Minnesota,Steele,1543,Steele,"36,649",TRUE
+Minnesota,Stevens,402,Stevens,"9,805",TRUE
+Minnesota,Swift,457,Swift,"9,266",TRUE
+Minnesota,Todd,1554,Todd,"24,664",TRUE
+Minnesota,Traverse,114,Traverse,"3,259",TRUE
+Minnesota,Wabasha,835,Wabasha,"21,627",TRUE
+Minnesota,Wadena,638,Wadena,"13,682",TRUE
+Minnesota,Waseca,1223,Waseca,"18,612",TRUE
+Minnesota,Washington,11756,Washington,"262,440",TRUE
+Minnesota,Watonwan,744,Watonwan,"10,897",TRUE
+Minnesota,Wilkin,299,Wilkin,"6,207",TRUE
+Minnesota,Winona,2334,Winona,"50,484",TRUE
+Minnesota,Wright,6046,Wright,"138,377",TRUE
+Mississippi,Adams,1318,Adams,"30,693",TRUE
+Mississippi,Alcorn,1410,Alcorn,"36,953",TRUE
+Mississippi,Amite,486,Amite,"12,297",TRUE
+Mississippi,Attala,1038,Attala,"18,174",TRUE
+Mississippi,Benton,480,Benton,"8,259",TRUE
+Mississippi,Bolivar,2350,Bolivar,"30,628",TRUE
+Mississippi,Calhoun,706,Calhoun,"14,361",TRUE
+Mississippi,Carroll,680,Carroll,"9,947",TRUE
+Mississippi,Chickasaw,1002,Chickasaw,"17,103",TRUE
+Mississippi,Choctaw,298,Choctaw,"8,210",TRUE
+Mississippi,Claiborne,572,Claiborne,"8,988",TRUE
+Mississippi,Clarke,866,Clarke,"15,541",TRUE
+Mississippi,Clay,843,Clay,"19,316",TRUE
+Mississippi,Coahoma,1442,Coahoma,"22,124",TRUE
+Mississippi,Copiah,1567,Copiah,"28,065",TRUE
+Mississippi,Covington,1142,Covington,"18,636",TRUE
+Mississippi,DeSoto,9358,DeSoto,"184,945",TRUE
+Mississippi,Forrest,3548,Forrest,"74,897",TRUE
+Mississippi,Franklin,308,Franklin,"7,713",TRUE
+Mississippi,George,1188,George,"24,500",TRUE
+Mississippi,Greene,573,Greene,"13,586",TRUE
+Mississippi,Grenada,1340,Grenada,"20,758",TRUE
+Mississippi,Hancock,1114,Hancock,"47,632",TRUE
+Mississippi,Harrison,6666,Harrison,"208,080",TRUE
+Mississippi,Hinds,9338,Hinds,"231,840",TRUE
+Mississippi,Holmes,1223,Holmes,"17,010",TRUE
+Mississippi,Humphreys,515,Humphreys,"8,064",TRUE
+Mississippi,Issaquena,108,Issaquena,"1,327",TRUE
+Mississippi,Itawamba,1424,Itawamba,"23,390",TRUE
+Mississippi,Jackson,5947,Jackson,"143,617",TRUE
+Mississippi,Jasper,788,Jasper,"16,383",TRUE
+Mississippi,Jefferson,332,Jefferson,"6,990",TRUE
+Mississippi,Jones,3371,Jones,"68,098",TRUE
+Mississippi,Kemper,395,Kemper,"9,742",TRUE
+Mississippi,Lafayette,3061,Lafayette,"54,019",TRUE
+Mississippi,Lamar,2689,Lamar,"63,343",TRUE
+Mississippi,Lauderdale,3224,Lauderdale,"74,125",TRUE
+Mississippi,Lawrence,685,Lawrence,"12,586",TRUE
+Mississippi,Leake,1292,Leake,"22,786",TRUE
+Mississippi,Lee,4672,Lee,"85,436",TRUE
+Mississippi,Leflore,1977,Leflore,"28,183",TRUE
+Mississippi,Lincoln,1766,Lincoln,"34,153",TRUE
+Mississippi,Lowndes,2218,Lowndes,"58,595",TRUE
+Mississippi,Madison,4498,Madison,"106,272",TRUE
+Mississippi,Marion,1071,Marion,"24,573",TRUE
+Mississippi,Marshall,2029,Marshall,"35,294",TRUE
+Mississippi,Monroe,1857,Monroe,"35,252",TRUE
+Mississippi,Montgomery,703,Montgomery,"9,775",TRUE
+Mississippi,Neshoba,2144,Neshoba,"29,118",TRUE
+Mississippi,Newton,1016,Newton,"21,018",TRUE
+Mississippi,Noxubee,678,Noxubee,"10,417",TRUE
+Mississippi,Oktibbeha,2351,Oktibbeha,"49,587",TRUE
+Mississippi,Panola,2050,Panola,"34,192",TRUE
+Mississippi,Perry,631,Perry,"11,973",TRUE
+Mississippi,Pike,1582,Pike,"39,288",TRUE
+Mississippi,Pontotoc,1875,Pontotoc,"32,174",TRUE
+Mississippi,Prentiss,1359,Prentiss,"25,126",TRUE
+Mississippi,Quitman,469,Quitman,"6,792",TRUE
+Mississippi,Rankin,5078,Rankin,"155,271",TRUE
+Mississippi,Scott,1452,Scott,"28,124",TRUE
+Mississippi,Sharkey,300,Sharkey,"4,321",TRUE
+Mississippi,Simpson,1394,Simpson,"26,658",TRUE
+Mississippi,Smith,672,Smith,"15,916",TRUE
+Mississippi,Stone,687,Stone,"18,336",TRUE
+Mississippi,Sunflower,1852,Sunflower,"25,110",TRUE
+Mississippi,Tallahatchie,941,Tallahatchie,"13,809",TRUE
+Mississippi,Tate,1574,Tate,"28,321",TRUE
+Mississippi,Tippah,1183,Tippah,"22,015",TRUE
+Mississippi,Tishomingo,1031,Tishomingo,"19,383",TRUE
+Mississippi,Tunica,590,Tunica,"9,632",TRUE
+Mississippi,Union,1555,Union,"28,815",TRUE
+Mississippi,Walthall,732,Walthall,"14,286",TRUE
+Mississippi,Warren,1691,Warren,"45,381",TRUE
+Mississippi,Washington,3002,Washington,"43,909",TRUE
+Mississippi,Wayne,1142,Wayne,"20,183",TRUE
+Mississippi,Webster,409,Webster,"9,689",TRUE
+Mississippi,Wilkinson,368,Wilkinson,"8,630",TRUE
+Mississippi,Winston,1116,Winston,"17,955",TRUE
+Mississippi,Yalobusha,659,Yalobusha,"12,108",TRUE
+Mississippi,Yazoo,1455,Yazoo,"29,690",TRUE
+Missouri,Adair,976,Adair,"25,343",TRUE
+Missouri,Andrew,681,Andrew,"17,712",TRUE
+Missouri,Atchison,180,Atchison,"5,143",TRUE
+Missouri,Audrain,921,Audrain,"25,388",TRUE
+Missouri,Barry,1333,Barry,"35,789",TRUE
+Missouri,Barton,588,Barton,"11,754",TRUE
+Missouri,Bates,450,Bates,"16,172",TRUE
+Missouri,Benton,711,Benton,"19,443",TRUE
+Missouri,Bollinger,741,Bollinger,"12,133",TRUE
+Missouri,Boone,9379,Boone,"180,463",TRUE
+Missouri,Buchanan,4095,Buchanan,"87,364",TRUE
+Missouri,Butler,1891,Butler,"42,478",TRUE
+Missouri,Caldwell,334,Caldwell,"9,020",TRUE
+Missouri,Callaway,2492,Callaway,"44,743",TRUE
+Missouri,Camden,2252,Camden,"46,305",TRUE
+Missouri,Carroll,353,Carroll,"8,679",TRUE
+Missouri,Carter,259,Carter,"5,982",TRUE
+Missouri,Cass,3281,Cass,"105,780",TRUE
+Missouri,Cedar,411,Cedar,"14,349",TRUE
+Missouri,Chariton,214,Chariton,"7,426",TRUE
+Missouri,Christian,3380,Christian,"88,595",TRUE
+Missouri,Clark,260,Clark,"6,797",TRUE
+Missouri,Clay,4115,Clay,"249,948",TRUE
+Missouri,Clinton,800,Clinton,"20,387",TRUE
+Missouri,Cole,5426,Cole,"76,745",TRUE
+Missouri,Cooper,1062,Cooper,"17,709",TRUE
+Missouri,Crawford,1056,Crawford,"23,920",TRUE
+Missouri,Dade,263,Dade,"7,561",TRUE
+Missouri,Dallas,553,Dallas,"16,878",TRUE
+Missouri,Daviess,301,Daviess,"8,278",TRUE
+Missouri,DeKalb,496,DeKalb,"12,547",TRUE
+Missouri,Dent,427,Dent,"15,573",TRUE
+Missouri,Douglas,377,Douglas,"13,185",TRUE
+Missouri,Dunklin,1558,Dunklin,"29,131",TRUE
+Missouri,Franklin,4247,Franklin,"103,967",TRUE
+Missouri,Gasconade,404,Gasconade,"14,706",TRUE
+Missouri,Gentry,355,Gentry,"6,571",TRUE
+Missouri,Greene,12531,Greene,"293,086",TRUE
+Missouri,Grundy,459,Grundy,"9,850",TRUE
+Missouri,Harrison,350,Harrison,"8,352",TRUE
+Missouri,Henry,933,Henry,"21,824",TRUE
+Missouri,Hickory,343,Hickory,"9,544",TRUE
+Missouri,Holt,226,Holt,"4,403",TRUE
+Missouri,Howard,422,Howard,"10,001",TRUE
+Missouri,Howell,1499,Howell,"40,117",TRUE
+Missouri,Iron,199,Iron,"10,125",TRUE
+Missouri,Jackson,35871,Jackson,"703,011",TRUE
+Missouri,Jasper,7548,Jasper,"121,328",TRUE
+Missouri,Jefferson,9362,Jefferson,"225,081",TRUE
+Missouri,Johnson,2261,Johnson,"54,062",TRUE
+Missouri,Knox,120,Knox,"3,959",TRUE
+Missouri,Laclede,1637,Laclede,"35,723",TRUE
+Missouri,Lafayette,1331,Lafayette,"32,708",TRUE
+Missouri,Lawrence,1742,Lawrence,"38,355",TRUE
+Missouri,Lewis,404,Lewis,"9,776",TRUE
+Missouri,Lincoln,2072,Lincoln,"59,013",TRUE
+Missouri,Linn,280,Linn,"11,920",TRUE
+Missouri,Livingston,714,Livingston,"15,227",TRUE
+Missouri,Mercer,68,Mercer,"3,617",TRUE
+Missouri,Miller,1369,Miller,"25,619",TRUE
+Missouri,Mississippi,684,Mississippi,"13,180",TRUE
+Missouri,Moniteau,1110,Moniteau,"16,132",TRUE
+Missouri,Monroe,326,Monroe,"8,644",TRUE
+Missouri,Montgomery,287,Montgomery,"11,551",TRUE
+Missouri,Morgan,972,Morgan,"20,627",TRUE
+Missouri,Newton,2766,Newton,"58,236",TRUE
+Missouri,Nodaway,1798,Nodaway,"22,092",TRUE
+Missouri,Oregon,343,Oregon,"10,529",TRUE
+Missouri,Osage,840,Osage,"13,615",TRUE
+Missouri,Ozark,266,Ozark,"9,174",TRUE
+Missouri,Pemiscot,1003,Pemiscot,"15,805",TRUE
+Missouri,Perry,1372,Perry,"19,136",TRUE
+Missouri,Pettis,2521,Pettis,"42,339",TRUE
+Missouri,Phelps,1449,Phelps,"44,573",TRUE
+Missouri,Pike,767,Pike,"18,302",TRUE
+Missouri,Platte,1459,Platte,"104,418",TRUE
+Missouri,Polk,1292,Polk,"32,149",TRUE
+Missouri,Pulaski,1418,Pulaski,"52,607",TRUE
+Missouri,Putnam,109,Putnam,"4,696",TRUE
+Missouri,Ralls,393,Ralls,"10,309",TRUE
+Missouri,Randolph,1075,Randolph,"24,748",TRUE
+Missouri,Ray,602,Ray,"23,018",TRUE
+Missouri,Reynolds,152,Reynolds,"6,270",TRUE
+Missouri,Ripley,448,Ripley,"13,288",TRUE
+Missouri,Saline,1442,Saline,"22,761",TRUE
+Missouri,Schuyler,118,Schuyler,"4,660",TRUE
+Missouri,Scotland,168,Scotland,"4,902",TRUE
+Missouri,Scott,2326,Scott,"38,280",TRUE
+Missouri,Shannon,320,Shannon,"8,166",TRUE
+Missouri,Shelby,172,Shelby,"5,930",TRUE
+Missouri,Stoddard,1418,Stoddard,"29,025",TRUE
+Missouri,Stone,1058,Stone,"31,952",TRUE
+Missouri,Sullivan,526,Sullivan,"6,089",TRUE
+Missouri,Taney,2523,Taney,"55,928",TRUE
+Missouri,Texas,880,Texas,"25,398",TRUE
+Missouri,Vernon,590,Vernon,"20,563",TRUE
+Missouri,Warren,1030,Warren,"35,649",TRUE
+Missouri,Washington,1256,Washington,"24,730",TRUE
+Missouri,Wayne,441,Wayne,"12,873",TRUE
+Missouri,Webster,1644,Webster,"39,592",TRUE
+Missouri,Worth,58,Worth,"2,013",TRUE
+Missouri,Wright,717,Wright,"18,289",TRUE
+Montana,Beaverhead,510,Beaverhead,"9,453",TRUE
+Montana,Blaine,476,Blaine,"6,681",TRUE
+Montana,Broadwater,157,Broadwater,"6,237",TRUE
+Montana,Carbon,519,Carbon,"10,725",TRUE
+Montana,Carter,105,Carter,"1,252",TRUE
+Montana,Cascade,4404,Cascade,"81,366",TRUE
+Montana,Chouteau,227,Chouteau,"5,635",TRUE
+Montana,Custer,642,Custer,"11,402",TRUE
+Montana,Daniels,88,Daniels,"1,690",TRUE
+Montana,Dawson,517,Dawson,"8,613",TRUE
+Montana,Fallon,219,Fallon,"2,846",TRUE
+Montana,Fergus,467,Fergus,"11,050",TRUE
+Montana,Flathead,5583,Flathead,"103,806",TRUE
+Montana,Gallatin,6353,Gallatin,"114,434",TRUE
+Montana,Garfield,59,Garfield,"1,258",TRUE
+Montana,Glacier,1145,Glacier,"13,753",TRUE
+Montana,Granite,113,Granite,"3,379",TRUE
+Montana,Hill,1213,Hill,"16,484",TRUE
+Montana,Jefferson,392,Jefferson,"12,221",TRUE
+Montana,Lake,895,Lake,"30,458",TRUE
+Montana,Liberty,65,Liberty,"2,337",TRUE
+Montana,Lincoln,655,Lincoln,"19,980",TRUE
+Montana,Meagher,103,Meagher,"1,862",TRUE
+Montana,Mineral,41,Mineral,"4,397",TRUE
+Montana,Missoula,3985,Missoula,"119,600",TRUE
+Montana,Musselshell,186,Musselshell,"4,633",TRUE
+Montana,Park,509,Park,"16,606",TRUE
+Montana,Petroleum,5,Petroleum,487,TRUE
+Montana,Phillips,242,Phillips,"3,954",TRUE
+Montana,Pondera,261,Pondera,"5,911",TRUE
+Montana,Powell,394,Powell,"6,890",TRUE
+Montana,Prairie,64,Prairie,"1,077",TRUE
+Montana,Ravalli,1157,Ravalli,"43,806",TRUE
+Montana,Richland,490,Richland,"10,803",TRUE
+Montana,Roosevelt,1170,Roosevelt,"11,004",TRUE
+Montana,Rosebud,837,Rosebud,"8,937",TRUE
+Montana,Sanders,190,Sanders,"12,113",TRUE
+Montana,Sheridan,226,Sheridan,"3,309",TRUE
+Montana,Stillwater,379,Stillwater,"9,642",TRUE
+Montana,Teton,158,Teton,"6,147",TRUE
+Montana,Toole,580,Toole,"4,736",TRUE
+Montana,Treasure,28,Treasure,696,TRUE
+Montana,Valley,524,Valley,"7,396",TRUE
+Montana,Wheatland,94,Wheatland,"2,126",TRUE
+Montana,Wibaux,73,Wibaux,969,TRUE
+Montana,Yellowstone,9798,Yellowstone,"161,300",TRUE
+Nebraska,Adams,1449,Adams,"31,363",TRUE
+Nebraska,Antelope,291,Antelope,"6,298",TRUE
+Nebraska,Arthur,14,Arthur,463,TRUE
+Nebraska,Banner,13,Banner,745,TRUE
+Nebraska,Blaine,14,Blaine,465,TRUE
+Nebraska,Boone,278,Boone,"5,192",TRUE
+Nebraska,Boyd,112,Boyd,"1,919",TRUE
+Nebraska,Brown,149,Brown,"2,955",TRUE
+Nebraska,Buffalo,3185,Buffalo,"49,659",TRUE
+Nebraska,Burt,359,Burt,"6,459",TRUE
+Nebraska,Butler,481,Butler,"8,016",TRUE
+Nebraska,Cass,996,Cass,"26,248",TRUE
+Nebraska,Cedar,313,Cedar,"8,402",TRUE
+Nebraska,Chase,244,Chase,"3,924",TRUE
+Nebraska,Cherry,161,Cherry,"5,689",TRUE
+Nebraska,Cheyenne,398,Cheyenne,"8,910",TRUE
+Nebraska,Clay,338,Clay,"6,203",TRUE
+Nebraska,Colfax,1222,Colfax,"10,709",TRUE
+Nebraska,Cuming,543,Cuming,"8,846",TRUE
+Nebraska,Custer,409,Custer,"10,777",TRUE
+Nebraska,Dakota,2995,Dakota,"20,026",TRUE
+Nebraska,Dawes,420,Dawes,"8,589",TRUE
+Nebraska,Dawson,1828,Dawson,"23,595",TRUE
+Nebraska,Deuel,32,Deuel,"1,794",TRUE
+Nebraska,Dixon,344,Dixon,"5,636",TRUE
+Nebraska,Dodge,2569,Dodge,"36,565",TRUE
+Nebraska,Douglas,35258,Douglas,"571,327",TRUE
+Nebraska,Dundy,53,Dundy,"1,693",TRUE
+Nebraska,Fillmore,289,Fillmore,"5,462",TRUE
+Nebraska,Franklin,156,Franklin,"2,979",TRUE
+Nebraska,Frontier,96,Frontier,"2,627",TRUE
+Nebraska,Furnas,216,Furnas,"4,676",TRUE
+Nebraska,Gage,1132,Gage,"21,513",TRUE
+Nebraska,Garden,69,Garden,"1,837",TRUE
+Nebraska,Garfield,86,Garfield,"1,969",TRUE
+Nebraska,Gosper,101,Gosper,"1,990",TRUE
+Nebraska,Grant,16,Grant,623,TRUE
+Nebraska,Greeley,109,Greeley,"2,356",TRUE
+Nebraska,Hall,4065,Hall,"61,353",TRUE
+Nebraska,Hamilton,457,Hamilton,"9,324",TRUE
+Nebraska,Harlan,115,Harlan,"3,380",TRUE
+Nebraska,Hayes,38,Hayes,922,TRUE
+Nebraska,Hitchcock,84,Hitchcock,"2,762",TRUE
+Nebraska,Holt,486,Holt,"10,067",TRUE
+Nebraska,Hooker,42,Hooker,682,TRUE
+Nebraska,Howard,313,Howard,"6,445",TRUE
+Nebraska,Jefferson,280,Jefferson,"7,046",TRUE
+Nebraska,Johnson,300,Johnson,"5,071",TRUE
+Nebraska,Kearney,448,Kearney,"6,495",TRUE
+Nebraska,Keith,301,Keith,"8,034",TRUE
+Nebraska,Kimball,147,Kimball,"3,632",TRUE
+Nebraska,Knox,392,Knox,"8,332",TRUE
+Nebraska,Lancaster,14150,Lancaster,"319,090",TRUE
+Nebraska,Lincoln,1956,Lincoln,"34,914",TRUE
+Nebraska,Logan,32,Logan,748,TRUE
+Nebraska,Loup,27,Loup,664,TRUE
+Nebraska,Merrick,395,Merrick,"7,755",TRUE
+Nebraska,Morrill,275,Morrill,"4,642",TRUE
+Nebraska,Nance,235,Nance,"3,519",TRUE
+Nebraska,Nemaha,276,Nemaha,"6,972",TRUE
+Nebraska,Nuckolls,179,Nuckolls,"4,148",TRUE
+Nebraska,Otoe,663,Otoe,"16,012",TRUE
+Nebraska,Pawnee,66,Pawnee,"2,613",TRUE
+Nebraska,Perkins,118,Perkins,"2,891",TRUE
+Nebraska,Phelps,486,Phelps,"9,034",TRUE
+Nebraska,Pierce,389,Pierce,"7,148",TRUE
+Nebraska,Platte,2863,Platte,"33,470",TRUE
+Nebraska,Polk,295,Polk,"5,213",TRUE
+Nebraska,Richardson,290,Richardson,"7,865",TRUE
+Nebraska,Rock,75,Rock,"1,357",TRUE
+Nebraska,Saline,1347,Saline,"14,224",TRUE
+Nebraska,Sarpy,10021,Sarpy,"187,196",TRUE
+Nebraska,Saunders,1100,Saunders,"21,578",TRUE
+Nebraska,Seward,725,Seward,"17,284",TRUE
+Nebraska,Sheridan,259,Sheridan,"5,246",TRUE
+Nebraska,Sherman,108,Sherman,"3,001",TRUE
+Nebraska,Sioux,18,Sioux,"1,166",TRUE
+Nebraska,Stanton,178,Stanton,"5,920",TRUE
+Nebraska,Thayer,208,Thayer,"5,003",TRUE
+Nebraska,Thomas,27,Thomas,722,TRUE
+Nebraska,Thurston,515,Thurston,"7,224",TRUE
+Nebraska,Valley,165,Valley,"4,158",TRUE
+Nebraska,Washington,1002,Washington,"20,729",TRUE
+Nebraska,Wayne,674,Wayne,"9,385",TRUE
+Nebraska,Webster,173,Webster,"3,487",TRUE
+Nebraska,Wheeler,11,Wheeler,783,TRUE
+Nebraska,York,875,York,"13,679",TRUE
+Nevada,Churchill,638,Churchill,"24,909",TRUE
+Nevada,Clark,101933,Clark,"2,266,715",TRUE
+Nevada,Douglas,516,Douglas,"48,905",TRUE
+Nevada,Elko,2207,Elko,"52,778",TRUE
+Nevada,Esmeralda,5,Esmeralda,873,TRUE
+Nevada,Eureka,22,Eureka,"2,029",TRUE
+Nevada,Humboldt,263,Humboldt,"16,831",TRUE
+Nevada,Lander,156,Lander,"5,532",TRUE
+Nevada,Lincoln,162,Lincoln,"5,183",TRUE
+Nevada,Lyon,743,Lyon,"57,510",TRUE
+Nevada,Mineral,61,Mineral,"4,505",TRUE
+Nevada,Nye,1122,Nye,"46,523",TRUE
+Nevada,Pershing,46,Pershing,"6,725",TRUE
+Nevada,Storey,31,Storey,"4,123",TRUE
+Nevada,Washoe,20046,Washoe,"471,519",TRUE
+New Hampshire,Belknap,510,Belknap,"61,303",TRUE
+New Hampshire,Carroll,284,Carroll,"48,910",TRUE
+New Hampshire,Cheshire,407,Cheshire,"76,085",TRUE
+New Hampshire,Coos,268,Coos,"31,563",TRUE
+New Hampshire,Grafton,452,Grafton,"89,886",TRUE
+New Hampshire,Hillsborough,7375,Hillsborough,"417,025",TRUE
+New Hampshire,Merrimack,1439,Merrimack,"151,391",TRUE
+New Hampshire,Rockingham,4013,Rockingham,"309,769",TRUE
+New Hampshire,Strafford,1367,Strafford,"130,633",TRUE
+New Hampshire,Sullivan,186,Sullivan,"43,146",TRUE
+New Jersey,Atlantic,7023,Atlantic,"263,670",TRUE
+New Jersey,Bergen,31006,Bergen,"932,202",TRUE
+New Jersey,Burlington,11411,Burlington,"445,349",TRUE
+New Jersey,Camden,16103,Camden,"506,471",TRUE
+New Jersey,Cumberland,4636,Cumberland,"149,527",TRUE
+New Jersey,Essex,31902,Essex,"798,975",TRUE
+New Jersey,Gloucester,7718,Gloucester,"291,636",TRUE
+New Jersey,Hudson,28370,Hudson,"672,391",TRUE
+New Jersey,Hunterdon,2155,Hunterdon,"124,371",TRUE
+New Jersey,Mercer,12087,Mercer,"367,430",TRUE
+New Jersey,Middlesex,27418,Middlesex,"825,062",TRUE
+New Jersey,Monmouth,18006,Monmouth,"618,795",TRUE
+New Jersey,Morris,11883,Morris,"491,845",TRUE
+New Jersey,Ocean,19648,Ocean,"607,186",TRUE
+New Jersey,Passaic,26415,Passaic,"501,826",TRUE
+New Jersey,Salem,1442,Salem,"62,385",TRUE
+New Jersey,Somerset,8146,Somerset,"328,934",TRUE
+New Jersey,Sussex,2245,Sussex,"140,488",TRUE
+New Jersey,Union,25437,Union,"556,341",TRUE
+New Jersey,Warren,2181,Warren,"105,267",TRUE
+New Mexico,Bernalillo,20539,Bernalillo,"679,121",TRUE
+New Mexico,Catron,29,Catron,"3,527",TRUE
+New Mexico,Chaves,3726,Chaves,"64,615",TRUE
+New Mexico,Cibola,1261,Cibola,"26,675",TRUE
+New Mexico,Colfax,127,Colfax,"11,941",TRUE
+New Mexico,Curry,2705,Curry,"48,954",TRUE
+New Mexico,Eddy,2436,Eddy,"58,460",TRUE
+New Mexico,Grant,397,Grant,"26,998",TRUE
+New Mexico,Guadalupe,93,Guadalupe,"4,300",TRUE
+New Mexico,Harding,4,Harding,625,TRUE
+New Mexico,Hidalgo,157,Hidalgo,"4,198",TRUE
+New Mexico,Lea,3451,Lea,"71,070",TRUE
+New Mexico,Lincoln,606,Lincoln,"19,572",TRUE
+New Mexico,Luna,1694,Luna,"23,709",TRUE
+New Mexico,McKinley,5778,McKinley,"71,367",TRUE
+New Mexico,Mora,31,Mora,"4,521",TRUE
+New Mexico,Otero,1146,Otero,"67,490",TRUE
+New Mexico,Quay,178,Quay,"8,253",TRUE
+New Mexico,Roosevelt,843,Roosevelt,"18,500",TRUE
+New Mexico,Sierra,227,Sierra,"10,791",TRUE
+New Mexico,Socorro,494,Socorro,"16,637",TRUE
+New Mexico,Taos,636,Taos,"32,723",TRUE
+New Mexico,Torrance,205,Torrance,"15,461",TRUE
+New Mexico,Union,90,Union,"4,059",TRUE
+New Mexico,Valencia,2155,Valencia,"76,688",TRUE
+New York,Albany,4906,Albany,"305,506",TRUE
+New York,Allegany,758,Allegany,"46,091",TRUE
+New York,Bronx,60233,Bronx,"1,418,207",TRUE
+New York,Broome,4688,Broome,"190,488",TRUE
+New York,Cattaraugus,809,Cattaraugus,"76,117",TRUE
+New York,Cayuga,681,Cayuga,"76,576",TRUE
+New York,Chautauqua,1351,Chautauqua,"126,903",TRUE
+New York,Chemung,2518,Chemung,"83,456",TRUE
+New York,Chenango,542,Chenango,"47,207",TRUE
+New York,Clinton,406,Clinton,"80,485",TRUE
+New York,Columbia,934,Columbia,"59,461",TRUE
+New York,Cortland,839,Cortland,"47,581",TRUE
+New York,Delaware,297,Delaware,"44,135",TRUE
+New York,Dutchess,6493,Dutchess,"294,218",TRUE
+New York,Erie,20103,Erie,"918,702",TRUE
+New York,Essex,240,Essex,"36,885",TRUE
+New York,Franklin,220,Franklin,"50,022",TRUE
+New York,Fulton,416,Fulton,"53,383",TRUE
+New York,Genesee,695,Genesee,"57,280",TRUE
+New York,Greene,604,Greene,"47,188",TRUE
+New York,Hamilton,35,Hamilton,"4,416",TRUE
+New York,Herkimer,552,Herkimer,"61,319",TRUE
+New York,Jefferson,376,Jefferson,"109,834",TRUE
+New York,Kings,83608,Kings,"2,559,903",TRUE
+New York,Lewis,284,Lewis,"26,296",TRUE
+New York,Livingston,549,Livingston,"62,914",TRUE
+New York,Madison,776,Madison,"70,941",TRUE
+New York,Monroe,11733,Monroe,"741,770",TRUE
+New York,Montgomery,364,Montgomery,"49,221",TRUE
+New York,Nassau,55875,Nassau,"1,356,924",TRUE
+New York,Niagara,3023,Niagara,"209,281",TRUE
+New York,Oneida,3896,Oneida,"228,671",TRUE
+New York,Onondaga,8735,Onondaga,"460,528",TRUE
+New York,Ontario,1039,Ontario,"109,777",TRUE
+New York,Orange,15677,Orange,"384,940",TRUE
+New York,Orleans,550,Orleans,"40,352",TRUE
+New York,Oswego,1101,Oswego,"117,124",TRUE
+New York,Otsego,497,Otsego,"59,493",TRUE
+New York,Putnam,2308,Putnam,"98,320",TRUE
+New York,Queens,84843,Queens,"2,253,858",TRUE
+New York,Rensselaer,1449,Rensselaer,"158,714",TRUE
+New York,Richmond,20586,Richmond,"476,143",TRUE
+New York,Rockland,20351,Rockland,"325,789",TRUE
+New York,Steuben,1502,Steuben,"95,379",TRUE
+New York,Suffolk,55329,Suffolk,"1,476,601",TRUE
+New York,Sullivan,2044,Sullivan,"75,432",TRUE
+New York,Tioga,998,Tioga,"48,203",TRUE
+New York,Tompkins,848,Tompkins,"102,180",TRUE
+New York,Ulster,2969,Ulster,"177,573",TRUE
+New York,Warren,530,Warren,"63,944",TRUE
+New York,Washington,414,Washington,"61,204",TRUE
+New York,Wayne,858,Wayne,"89,918",TRUE
+New York,Westchester,46064,Westchester,"967,506",TRUE
+New York,Wyoming,384,Wyoming,"39,859",TRUE
+New York,Yates,220,Yates,"24,913",TRUE
+North Carolina,Alamance,6429,Alamance,"169,509",TRUE
+North Carolina,Alexander,1396,Alexander,"37,497",TRUE
+North Carolina,Alleghany,370,Alleghany,"11,137",TRUE
+North Carolina,Anson,848,Anson,"24,446",TRUE
+North Carolina,Ashe,693,Ashe,"27,203",TRUE
+North Carolina,Avery,838,Avery,"17,557",TRUE
+North Carolina,Beaufort,1600,Beaufort,"46,994",TRUE
+North Carolina,Bertie,828,Bertie,"18,947",TRUE
+North Carolina,Bladen,1244,Bladen,"32,722",TRUE
+North Carolina,Brunswick,2696,Brunswick,"142,820",TRUE
+North Carolina,Buncombe,5075,Buncombe,"261,191",TRUE
+North Carolina,Burke,3425,Burke,"90,485",TRUE
+North Carolina,Cabarrus,6197,Cabarrus,"216,453",TRUE
+North Carolina,Caldwell,3187,Caldwell,"82,178",TRUE
+North Carolina,Camden,167,Camden,"10,867",TRUE
+North Carolina,Carteret,1539,Carteret,"69,473",TRUE
+North Carolina,Caswell,766,Caswell,"22,604",TRUE
+North Carolina,Catawba,6056,Catawba,"159,551",TRUE
+North Carolina,Chatham,2248,Chatham,"74,470",TRUE
+North Carolina,Cherokee,887,Cherokee,"28,612",TRUE
+North Carolina,Chowan,579,Chowan,"13,943",TRUE
+North Carolina,Clay,269,Clay,"11,231",TRUE
+North Carolina,Cleveland,3916,Cleveland,"97,947",TRUE
+North Carolina,Columbus,2404,Columbus,"55,508",TRUE
+North Carolina,Craven,2842,Craven,"102,139",TRUE
+North Carolina,Cumberland,8672,Cumberland,"335,509",TRUE
+North Carolina,Currituck,301,Currituck,"27,763",TRUE
+North Carolina,Dare,574,Dare,"37,009",TRUE
+North Carolina,Davidson,4730,Davidson,"167,609",TRUE
+North Carolina,Davie,1074,Davie,"42,846",TRUE
+North Carolina,Duplin,3177,Duplin,"58,741",TRUE
+North Carolina,Durham,10575,Durham,"321,488",TRUE
+North Carolina,Edgecombe,2365,Edgecombe,"51,472",TRUE
+North Carolina,Forsyth,11723,Forsyth,"382,295",TRUE
+North Carolina,Franklin,1798,Franklin,"69,685",TRUE
+North Carolina,Gaston,9338,Gaston,"224,529",TRUE
+North Carolina,Gates,190,Gates,"11,562",TRUE
+North Carolina,Graham,268,Graham,"8,441",TRUE
+North Carolina,Granville,2362,Granville,"60,443",TRUE
+North Carolina,Greene,1128,Greene,"21,069",TRUE
+North Carolina,Guilford,14942,Guilford,"537,174",TRUE
+North Carolina,Halifax,1812,Halifax,"50,010",TRUE
+North Carolina,Harnett,3635,Harnett,"135,976",TRUE
+North Carolina,Haywood,963,Haywood,"62,317",TRUE
+North Carolina,Henderson,2908,Henderson,"117,417",TRUE
+North Carolina,Hertford,934,Hertford,"23,677",TRUE
+North Carolina,Hoke,1848,Hoke,"55,234",TRUE
+North Carolina,Hyde,181,Hyde,"4,937",TRUE
+North Carolina,Iredell,4874,Iredell,"181,806",TRUE
+North Carolina,Jackson,1315,Jackson,"43,938",TRUE
+North Carolina,Johnston,6988,Johnston,"209,339",TRUE
+North Carolina,Jones,232,Jones,"9,419",TRUE
+North Carolina,Lee,2350,Lee,"61,779",TRUE
+North Carolina,Lenoir,1910,Lenoir,"55,949",TRUE
+North Carolina,Lincoln,3081,Lincoln,"86,111",TRUE
+North Carolina,Mecklenburg,39880,Mecklenburg,"1,110,356",TRUE
+North Carolina,Mitchell,447,Mitchell,"14,964",TRUE
+North Carolina,Montgomery,1324,Montgomery,"27,173",TRUE
+North Carolina,Moore,2677,Moore,"100,880",TRUE
+North Carolina,Nash,4130,Nash,"94,298",TRUE
+North Carolina,Northampton,709,Northampton,"19,483",TRUE
+North Carolina,Onslow,4553,Onslow,"197,938",TRUE
+North Carolina,Orange,3648,Orange,"148,476",TRUE
+North Carolina,Pamlico,359,Pamlico,"12,726",TRUE
+North Carolina,Pasquotank,1013,Pasquotank,"39,824",TRUE
+North Carolina,Pender,1713,Pender,"63,060",TRUE
+North Carolina,Perquimans,308,Perquimans,"13,463",TRUE
+North Carolina,Person,865,Person,"39,490",TRUE
+North Carolina,Pitt,7285,Pitt,"180,742",TRUE
+North Carolina,Polk,449,Polk,"20,724",TRUE
+North Carolina,Randolph,4878,Randolph,"143,667",TRUE
+North Carolina,Richmond,1728,Richmond,"44,829",TRUE
+North Carolina,Robeson,6915,Robeson,"130,625",TRUE
+North Carolina,Rockingham,2710,Rockingham,"91,010",TRUE
+North Carolina,Rowan,5133,Rowan,"142,088",TRUE
+North Carolina,Rutherford,2136,Rutherford,"67,029",TRUE
+North Carolina,Sampson,3367,Sampson,"63,531",TRUE
+North Carolina,Scotland,1833,Scotland,"34,823",TRUE
+North Carolina,Stanly,2764,Stanly,"62,806",TRUE
+North Carolina,Stokes,1002,Stokes,"45,591",TRUE
+North Carolina,Surry,2526,Surry,"71,783",TRUE
+North Carolina,Swain,359,Swain,"14,271",TRUE
+North Carolina,Transylvania,502,Transylvania,"34,385",TRUE
+North Carolina,Tyrrell,137,Tyrrell,"4,016",TRUE
+North Carolina,Union,7130,Union,"239,859",TRUE
+North Carolina,Vance,1533,Vance,"44,535",TRUE
+North Carolina,Wake,25975,Wake,"1,111,761",TRUE
+North Carolina,Warren,571,Warren,"19,731",TRUE
+North Carolina,Washington,294,Washington,"11,580",TRUE
+North Carolina,Watauga,1679,Watauga,"56,177",TRUE
+North Carolina,Wayne,5357,Wayne,"123,131",TRUE
+North Carolina,Wilkes,2422,Wilkes,"68,412",TRUE
+North Carolina,Wilson,3709,Wilson,"81,801",TRUE
+North Carolina,Yadkin,1341,Yadkin,"37,667",TRUE
+North Carolina,Yancey,476,Yancey,"18,069",TRUE
+North Dakota,Adams,149,Adams,"2,216",TRUE
+North Dakota,Barnes,865,Barnes,"10,415",TRUE
+North Dakota,Benson,699,Benson,"6,832",TRUE
+North Dakota,Billings,38,Billings,928,TRUE
+North Dakota,Bottineau,479,Bottineau,"6,282",TRUE
+North Dakota,Bowman,177,Bowman,"3,024",TRUE
+North Dakota,Burke,161,Burke,"2,115",TRUE
+North Dakota,Burleigh,10658,Burleigh,"95,626",TRUE
+North Dakota,Cass,14630,Cass,"181,923",TRUE
+North Dakota,Cavalier,299,Cavalier,"3,762",TRUE
+North Dakota,Dickey,509,Dickey,"4,872",TRUE
+North Dakota,Divide,115,Divide,"2,264",TRUE
+North Dakota,Dunn,273,Dunn,"4,424",TRUE
+North Dakota,Eddy,337,Eddy,"2,287",TRUE
+North Dakota,Emmons,325,Emmons,"3,241",TRUE
+North Dakota,Foster,410,Foster,"3,210",TRUE
+North Dakota,Grant,138,Grant,"2,274",TRUE
+North Dakota,Griggs,198,Griggs,"2,231",TRUE
+North Dakota,Hettinger,208,Hettinger,"2,499",TRUE
+North Dakota,Kidder,164,Kidder,"2,480",TRUE
+North Dakota,LaMoure,321,LaMoure,"4,046",TRUE
+North Dakota,Logan,151,Logan,"1,850",TRUE
+North Dakota,McHenry,408,McHenry,"5,745",TRUE
+North Dakota,McIntosh,226,McIntosh,"2,497",TRUE
+North Dakota,McKenzie,805,McKenzie,"15,024",TRUE
+North Dakota,McLean,885,McLean,"9,450",TRUE
+North Dakota,Mercer,778,Mercer,"8,187",TRUE
+North Dakota,Morton,3625,Morton,"31,364",TRUE
+North Dakota,Mountrail,960,Mountrail,"10,545",TRUE
+North Dakota,Nelson,319,Nelson,"2,879",TRUE
+North Dakota,Oliver,115,Oliver,"1,959",TRUE
+North Dakota,Pembina,525,Pembina,"6,801",TRUE
+North Dakota,Pierce,342,Pierce,"3,975",TRUE
+North Dakota,Ramsey,1002,Ramsey,"11,519",TRUE
+North Dakota,Ransom,383,Ransom,"5,218",TRUE
+North Dakota,Renville,185,Renville,"2,327",TRUE
+North Dakota,Richland,970,Richland,"16,177",TRUE
+North Dakota,Rolette,1227,Rolette,"14,176",TRUE
+North Dakota,Sargent,248,Sargent,"3,898",TRUE
+North Dakota,Sheridan,73,Sheridan,"1,315",TRUE
+North Dakota,Sioux,398,Sioux,"4,230",TRUE
+North Dakota,Slope,19,Slope,750,TRUE
+North Dakota,Stark,3234,Stark,"31,489",TRUE
+North Dakota,Steele,107,Steele,"1,890",TRUE
+North Dakota,Stutsman,2294,Stutsman,"20,704",TRUE
+North Dakota,Towner,187,Towner,"2,189",TRUE
+North Dakota,Traill,622,Traill,"8,036",TRUE
+North Dakota,Walsh,1310,Walsh,"10,641",TRUE
+North Dakota,Ward,6802,Ward,"67,641",TRUE
+North Dakota,Wells,283,Wells,"3,834",TRUE
+North Dakota,Williams,2759,Williams,"37,589",TRUE
+Ohio,Adams,678,Adams,"27,698",TRUE
+Ohio,Allen,4353,Allen,"102,351",TRUE
+Ohio,Ashland,920,Ashland,"53,484",TRUE
+Ohio,Ashtabula,1915,Ashtabula,"97,241",TRUE
+Ohio,Athens,1730,Athens,"65,327",TRUE
+Ohio,Auglaize,2107,Auglaize,"45,656",TRUE
+Ohio,Belmont,1462,Belmont,"67,006",TRUE
+Ohio,Brown,866,Brown,"43,432",TRUE
+Ohio,Butler,13610,Butler,"383,134",TRUE
+Ohio,Carroll,398,Carroll,"26,914",TRUE
+Ohio,Champaign,850,Champaign,"38,885",TRUE
+Ohio,Clark,4633,Clark,"134,083",TRUE
+Ohio,Clermont,5135,Clermont,"206,428",TRUE
+Ohio,Clinton,964,Clinton,"41,968",TRUE
+Ohio,Columbiana,3165,Columbiana,"101,883",TRUE
+Ohio,Coshocton,757,Coshocton,"36,600",TRUE
+Ohio,Crawford,1072,Crawford,"41,494",TRUE
+Ohio,Cuyahoga,32296,Cuyahoga,"1,235,072",TRUE
+Ohio,Darke,1999,Darke,"51,113",TRUE
+Ohio,Defiance,1250,Defiance,"38,087",TRUE
+Ohio,Delaware,4881,Delaware,"209,177",TRUE
+Ohio,Erie,1945,Erie,"74,266",TRUE
+Ohio,Fairfield,4823,Fairfield,"157,574",TRUE
+Ohio,Fayette,840,Fayette,"28,525",TRUE
+Ohio,Franklin,46473,Franklin,"1,316,756",TRUE
+Ohio,Fulton,1123,Fulton,"42,126",TRUE
+Ohio,Gallia,601,Gallia,"29,898",TRUE
+Ohio,Geauga,1776,Geauga,"93,649",TRUE
+Ohio,Greene,4710,Greene,"168,937",TRUE
+Ohio,Guernsey,759,Guernsey,"38,875",TRUE
+Ohio,Hamilton,27724,Hamilton,"817,473",TRUE
+Ohio,Hancock,2093,Hancock,"75,783",TRUE
+Ohio,Hardin,781,Hardin,"31,365",TRUE
+Ohio,Harrison,171,Harrison,"15,040",TRUE
+Ohio,Henry,890,Henry,"27,006",TRUE
+Ohio,Highland,923,Highland,"43,161",TRUE
+Ohio,Hocking,542,Hocking,"28,264",TRUE
+Ohio,Holmes,1328,Holmes,"43,960",TRUE
+Ohio,Huron,1325,Huron,"58,266",TRUE
+Ohio,Jackson,830,Jackson,"32,413",TRUE
+Ohio,Jefferson,957,Jefferson,"65,325",TRUE
+Ohio,Knox,1100,Knox,"62,322",TRUE
+Ohio,Lake,5861,Lake,"230,149",TRUE
+Ohio,Lawrence,1733,Lawrence,"59,463",TRUE
+Ohio,Licking,4806,Licking,"176,862",TRUE
+Ohio,Logan,1089,Logan,"45,672",TRUE
+Ohio,Lorain,5565,Lorain,"309,833",TRUE
+Ohio,Lucas,13035,Lucas,"428,348",TRUE
+Ohio,Madison,1447,Madison,"44,731",TRUE
+Ohio,Mahoning,6459,Mahoning,"228,683",TRUE
+Ohio,Marion,4374,Marion,"65,093",TRUE
+Ohio,Medina,3875,Medina,"179,746",TRUE
+Ohio,Meigs,337,Meigs,"22,907",TRUE
+Ohio,Mercer,2745,Mercer,"41,172",TRUE
+Ohio,Miami,3813,Miami,"106,987",TRUE
+Ohio,Monroe,280,Monroe,"13,654",TRUE
+Ohio,Montgomery,18176,Montgomery,"531,687",TRUE
+Ohio,Morgan,208,Morgan,"14,508",TRUE
+Ohio,Morrow,780,Morrow,"35,328",TRUE
+Ohio,Muskingum,2100,Muskingum,"86,215",TRUE
+Ohio,Noble,538,Noble,"14,424",TRUE
+Ohio,Ottawa,1090,Ottawa,"40,525",TRUE
+Ohio,Paulding,565,Paulding,"18,672",TRUE
+Ohio,Perry,688,Perry,"36,134",TRUE
+Ohio,Pickaway,3813,Pickaway,"58,457",TRUE
+Ohio,Pike,661,Pike,"27,772",TRUE
+Ohio,Portage,3027,Portage,"162,466",TRUE
+Ohio,Preble,1367,Preble,"40,882",TRUE
+Ohio,Putnam,2125,Putnam,"33,861",TRUE
+Ohio,Richland,2726,Richland,"121,154",TRUE
+Ohio,Ross,2253,Ross,"76,666",TRUE
+Ohio,Sandusky,1370,Sandusky,"58,518",TRUE
+Ohio,Scioto,1773,Scioto,"75,314",TRUE
+Ohio,Seneca,1563,Seneca,"55,178",TRUE
+Ohio,Shelby,1678,Shelby,"48,590",TRUE
+Ohio,Stark,7655,Stark,"370,606",TRUE
+Ohio,Summit,11890,Summit,"541,013",TRUE
+Ohio,Trumbull,4682,Trumbull,"197,974",TRUE
+Ohio,Tuscarawas,2874,Tuscarawas,"91,987",TRUE
+Ohio,Union,1707,Union,"58,988",TRUE
+Ohio,Vinton,197,Vinton,"13,085",TRUE
+Ohio,Warren,7373,Warren,"234,602",TRUE
+Ohio,Washington,967,Washington,"59,911",TRUE
+Ohio,Wayne,2933,Wayne,"115,710",TRUE
+Ohio,Williams,953,Williams,"36,692",TRUE
+Ohio,Wood,4083,Wood,"130,817",TRUE
+Ohio,Wyandot,623,Wyandot,"21,772",TRUE
+Oklahoma,Adair,1115,Adair,"22,194",TRUE
+Oklahoma,Alfalfa,271,Alfalfa,"5,702",TRUE
+Oklahoma,Atoka,748,Atoka,"13,758",TRUE
+Oklahoma,Beaver,154,Beaver,"5,311",TRUE
+Oklahoma,Beckham,1146,Beckham,"21,859",TRUE
+Oklahoma,Blaine,306,Blaine,"9,429",TRUE
+Oklahoma,Bryan,2508,Bryan,"47,995",TRUE
+Oklahoma,Caddo,1566,Caddo,"28,762",TRUE
+Oklahoma,Canadian,5913,Canadian,"148,306",TRUE
+Oklahoma,Carter,1355,Carter,"48,111",TRUE
+Oklahoma,Cherokee,1954,Cherokee,"48,657",TRUE
+Oklahoma,Choctaw,628,Choctaw,"14,672",TRUE
+Oklahoma,Cimarron,60,Cimarron,"2,137",TRUE
+Oklahoma,Cleveland,11158,Cleveland,"284,014",TRUE
+Oklahoma,Coal,237,Coal,"5,495",TRUE
+Oklahoma,Comanche,3901,Comanche,"120,749",TRUE
+Oklahoma,Cotton,176,Cotton,"5,666",TRUE
+Oklahoma,Craig,828,Craig,"14,142",TRUE
+Oklahoma,Creek,2263,Creek,"71,522",TRUE
+Oklahoma,Custer,1598,Custer,"29,003",TRUE
+Oklahoma,Delaware,1719,Delaware,"43,009",TRUE
+Oklahoma,Dewey,158,Dewey,"4,891",TRUE
+Oklahoma,Ellis,111,Ellis,"3,859",TRUE
+Oklahoma,Garfield,3224,Garfield,"61,056",TRUE
+Oklahoma,Garvin,1348,Garvin,"27,711",TRUE
+Oklahoma,Grady,2288,Grady,"55,834",TRUE
+Oklahoma,Grant,187,Grant,"4,333",TRUE
+Oklahoma,Greer,213,Greer,"5,712",TRUE
+Oklahoma,Harmon,95,Harmon,"2,653",TRUE
+Oklahoma,Harper,139,Harper,"3,688",TRUE
+Oklahoma,Haskell,595,Haskell,"12,627",TRUE
+Oklahoma,Hughes,537,Hughes,"13,279",TRUE
+Oklahoma,Jackson,1612,Jackson,"24,530",TRUE
+Oklahoma,Jefferson,152,Jefferson,"6,002",TRUE
+Oklahoma,Johnston,456,Johnston,"11,085",TRUE
+Oklahoma,Kay,1465,Kay,"43,538",TRUE
+Oklahoma,Kingfisher,773,Kingfisher,"15,765",TRUE
+Oklahoma,Kiowa,284,Kiowa,"8,708",TRUE
+Oklahoma,Latimer,288,Latimer,"10,073",TRUE
+Oklahoma,Lincoln,1152,Lincoln,"34,877",TRUE
+Oklahoma,Logan,1197,Logan,"48,011",TRUE
+Oklahoma,Love,480,Love,"10,253",TRUE
+Oklahoma,Murray,529,Murray,"14,073",TRUE
+Oklahoma,Muskogee,3757,Muskogee,"67,997",TRUE
+Oklahoma,Noble,350,Noble,"11,131",TRUE
+Oklahoma,Nowata,364,Nowata,"10,076",TRUE
+Oklahoma,Okfuskee,882,Okfuskee,"11,993",TRUE
+Oklahoma,Oklahoma,33851,Oklahoma,"797,434",TRUE
+Oklahoma,Okmulgee,1633,Okmulgee,"38,465",TRUE
+Oklahoma,Osage,1774,Osage,"46,963",TRUE
+Oklahoma,Ottawa,1573,Ottawa,"31,127",TRUE
+Oklahoma,Pawnee,488,Pawnee,"16,376",TRUE
+Oklahoma,Payne,3745,Payne,"81,784",TRUE
+Oklahoma,Pittsburg,1713,Pittsburg,"43,654",TRUE
+Oklahoma,Pontotoc,1579,Pontotoc,"38,284",TRUE
+Oklahoma,Pottawatomie,2988,Pottawatomie,"72,592",TRUE
+Oklahoma,Pushmataha,389,Pushmataha,"11,096",TRUE
+Oklahoma,Rogers,3535,Rogers,"92,459",TRUE
+Oklahoma,Seminole,1125,Seminole,"24,258",TRUE
+Oklahoma,Sequoyah,1664,Sequoyah,"41,569",TRUE
+Oklahoma,Stephens,1312,Stephens,"43,143",TRUE
+Oklahoma,Texas,2177,Texas,"19,983",TRUE
+Oklahoma,Tillman,268,Tillman,"7,250",TRUE
+Oklahoma,Tulsa,28966,Tulsa,"651,552",TRUE
+Oklahoma,Wagoner,2437,Wagoner,"81,289",TRUE
+Oklahoma,Washington,1749,Washington,"51,527",TRUE
+Oklahoma,Washita,302,Washita,"10,916",TRUE
+Oklahoma,Woods,410,Woods,"8,793",TRUE
+Oklahoma,Woodward,1644,Woodward,"20,211",TRUE
+Oregon,Baker,248,Baker,"16,124",TRUE
+Oregon,Benton,679,Benton,"93,053",TRUE
+Oregon,Clackamas,5025,Clackamas,"418,187",TRUE
+Oregon,Clatsop,321,Clatsop,"40,224",TRUE
+Oregon,Columbia,405,Columbia,"52,354",TRUE
+Oregon,Coos,368,Coos,"64,487",TRUE
+Oregon,Crook,183,Crook,"24,404",TRUE
+Oregon,Curry,101,Curry,"22,925",TRUE
+Oregon,Deschutes,1841,Deschutes,"197,692",TRUE
+Oregon,Douglas,756,Douglas,"110,980",TRUE
+Oregon,Gilliam,21,Gilliam,"1,912",TRUE
+Oregon,Grant,101,Grant,"7,199",TRUE
+Oregon,Harney,82,Harney,"7,393",TRUE
+Oregon,Jackson,3240,Jackson,"220,944",TRUE
+Oregon,Jefferson,749,Jefferson,"24,658",TRUE
+Oregon,Josephine,401,Josephine,"87,487",TRUE
+Oregon,Klamath,612,Klamath,"68,238",TRUE
+Oregon,Lake,85,Lake,"7,869",TRUE
+Oregon,Lane,3672,Lane,"382,067",TRUE
+Oregon,Lincoln,559,Lincoln,"49,962",TRUE
+Oregon,Linn,1188,Linn,"129,749",TRUE
+Oregon,Malheur,2265,Malheur,"30,571",TRUE
+Oregon,Marion,8025,Marion,"347,818",TRUE
+Oregon,Morrow,602,Morrow,"11,603",TRUE
+Oregon,Multnomah,14060,Multnomah,"812,855",TRUE
+Oregon,Polk,983,Polk,"86,085",TRUE
+Oregon,Sherman,23,Sherman,"1,780",TRUE
+Oregon,Tillamook,111,Tillamook,"27,036",TRUE
+Oregon,Umatilla,4013,Umatilla,"77,950",TRUE
+Oregon,Union,655,Union,"26,835",TRUE
+Oregon,Wallowa,70,Wallowa,"7,208",TRUE
+Oregon,Wasco,447,Wasco,"26,682",TRUE
+Oregon,Washington,8466,Washington,"601,592",TRUE
+Oregon,Wheeler,1,Wheeler,"1,332",TRUE
+Oregon,Yamhill,1468,Yamhill,"107,100",TRUE
+Pennsylvania,Adams,1636,Adams,"103,009",TRUE
+Pennsylvania,Allegheny,22527,Allegheny,"1,216,045",TRUE
+Pennsylvania,Armstrong,1441,Armstrong,"64,735",TRUE
+Pennsylvania,Beaver,3154,Beaver,"163,929",TRUE
+Pennsylvania,Bedford,1113,Bedford,"47,888",TRUE
+Pennsylvania,Berks,12215,Berks,"421,164",TRUE
+Pennsylvania,Blair,3105,Blair,"121,829",TRUE
+Pennsylvania,Bradford,1605,Bradford,"60,323",TRUE
+Pennsylvania,Bucks,14465,Bucks,"628,270",TRUE
+Pennsylvania,Butler,3426,Butler,"187,853",TRUE
+Pennsylvania,Cambria,2877,Cambria,"130,192",TRUE
+Pennsylvania,Cameron,17,Cameron,"4,447",TRUE
+Pennsylvania,Carbon,1008,Carbon,"64,182",TRUE
+Pennsylvania,Centre,5502,Centre,"162,385",TRUE
+Pennsylvania,Chester,10505,Chester,"524,989",TRUE
+Pennsylvania,Clarion,651,Clarion,"38,438",TRUE
+Pennsylvania,Clearfield,1076,Clearfield,"79,255",TRUE
+Pennsylvania,Clinton,490,Clinton,"38,632",TRUE
+Pennsylvania,Columbia,1309,Columbia,"64,964",TRUE
+Pennsylvania,Crawford,1362,Crawford,"84,629",TRUE
+Pennsylvania,Cumberland,4017,Cumberland,"253,370",TRUE
+Pennsylvania,Dauphin,6637,Dauphin,"278,299",TRUE
+Pennsylvania,Delaware,17899,Delaware,"566,747",TRUE
+Pennsylvania,Elk,407,Elk,"29,910",TRUE
+Pennsylvania,Erie,4096,Erie,"269,728",TRUE
+Pennsylvania,Fayette,1596,Fayette,"129,274",TRUE
+Pennsylvania,Forest,51,Forest,"7,247",TRUE
+Pennsylvania,Franklin,3582,Franklin,"155,027",TRUE
+Pennsylvania,Fulton,198,Fulton,"14,530",TRUE
+Pennsylvania,Greene,558,Greene,"36,233",TRUE
+Pennsylvania,Huntingdon,1488,Huntingdon,"45,144",TRUE
+Pennsylvania,Indiana,2062,Indiana,"84,073",TRUE
+Pennsylvania,Jefferson,521,Jefferson,"43,425",TRUE
+Pennsylvania,Juniata,535,Juniata,"24,763",TRUE
+Pennsylvania,Lackawanna,4597,Lackawanna,"209,674",TRUE
+Pennsylvania,Lancaster,13564,Lancaster,"545,724",TRUE
+Pennsylvania,Lawrence,1776,Lawrence,"85,512",TRUE
+Pennsylvania,Lebanon,4444,Lebanon,"141,793",TRUE
+Pennsylvania,Lehigh,9453,Lehigh,"369,318",TRUE
+Pennsylvania,Luzerne,7966,Luzerne,"317,417",TRUE
+Pennsylvania,Lycoming,1580,Lycoming,"113,299",TRUE
+Pennsylvania,McKean,332,McKean,"40,625",TRUE
+Pennsylvania,Mercer,2198,Mercer,"109,424",TRUE
+Pennsylvania,Mifflin,1202,Mifflin,"46,138",TRUE
+Pennsylvania,Monroe,2782,Monroe,"170,271",TRUE
+Pennsylvania,Montgomery,18861,Montgomery,"830,915",TRUE
+Pennsylvania,Montour,399,Montour,"18,230",TRUE
+Pennsylvania,Northampton,7472,Northampton,"305,285",TRUE
+Pennsylvania,Northumberland,2118,Northumberland,"90,843",TRUE
+Pennsylvania,Perry,553,Perry,"46,272",TRUE
+Pennsylvania,Philadelphia,59081,Philadelphia,"1,584,064",TRUE
+Pennsylvania,Pike,774,Pike,"55,809",TRUE
+Pennsylvania,Potter,125,Potter,"16,526",TRUE
+Pennsylvania,Schuylkill,3240,Schuylkill,"141,359",TRUE
+Pennsylvania,Snyder,819,Snyder,"40,372",TRUE
+Pennsylvania,Somerset,1165,Somerset,"73,447",TRUE
+Pennsylvania,Sullivan,41,Sullivan,"6,066",TRUE
+Pennsylvania,Susquehanna,535,Susquehanna,"40,328",TRUE
+Pennsylvania,Tioga,658,Tioga,"40,591",TRUE
+Pennsylvania,Union,1187,Union,"44,923",TRUE
+Pennsylvania,Venango,674,Venango,"50,668",TRUE
+Pennsylvania,Warren,154,Warren,"39,191",TRUE
+Pennsylvania,Washington,3596,Washington,"206,865",TRUE
+Pennsylvania,Wayne,383,Wayne,"51,361",TRUE
+Pennsylvania,Westmoreland,7097,Westmoreland,"348,899",TRUE
+Pennsylvania,Wyoming,372,Wyoming,"26,794",TRUE
+Pennsylvania,York,8975,York,"449,058",TRUE
+Rhode Island,Bristol,1044,Bristol,"48,479",TRUE
+Rhode Island,Kent,4152,Kent,"164,292",TRUE
+Rhode Island,Newport,1046,Newport,"82,082",TRUE
+Rhode Island,Providence,31512,Providence,"638,931",TRUE
+Rhode Island,Washington,1891,Washington,"125,577",TRUE
+South Carolina,Abbeville,901,Abbeville,"24,527",TRUE
+South Carolina,Aiken,5950,Aiken,"170,872",TRUE
+South Carolina,Allendale,445,Allendale,"8,688",TRUE
+South Carolina,Anderson,7395,Anderson,"202,558",TRUE
+South Carolina,Bamberg,717,Bamberg,"14,066",TRUE
+South Carolina,Barnwell,942,Barnwell,"20,866",TRUE
+South Carolina,Beaufort,6785,Beaufort,"192,122",TRUE
+South Carolina,Berkeley,6841,Berkeley,"227,907",TRUE
+South Carolina,Calhoun,543,Calhoun,"14,553",TRUE
+South Carolina,Charleston,19075,Charleston,"411,406",TRUE
+South Carolina,Cherokee,1942,Cherokee,"57,300",TRUE
+South Carolina,Chester,1446,Chester,"32,244",TRUE
+South Carolina,Chesterfield,1681,Chesterfield,"45,650",TRUE
+South Carolina,Clarendon,1313,Clarendon,"33,745",TRUE
+South Carolina,Colleton,1440,Colleton,"37,677",TRUE
+South Carolina,Darlington,2892,Darlington,"66,618",TRUE
+South Carolina,Dillon,1471,Dillon,"30,479",TRUE
+South Carolina,Dorchester,5474,Dorchester,"162,809",TRUE
+South Carolina,Edgefield,1108,Edgefield,"27,260",TRUE
+South Carolina,Fairfield,998,Fairfield,"22,347",TRUE
+South Carolina,Florence,6349,Florence,"138,293",TRUE
+South Carolina,Georgetown,2664,Georgetown,"62,680",TRUE
+South Carolina,Greenville,21843,Greenville,"523,542",TRUE
+South Carolina,Greenwood,2911,Greenwood,"70,811",TRUE
+South Carolina,Hampton,836,Hampton,"19,222",TRUE
+South Carolina,Horry,14051,Horry,"354,081",TRUE
+South Carolina,Jasper,1009,Jasper,"30,073",TRUE
+South Carolina,Kershaw,2823,Kershaw,"66,551",TRUE
+South Carolina,Lancaster,3242,Lancaster,"98,012",TRUE
+South Carolina,Laurens,2323,Laurens,"67,493",TRUE
+South Carolina,Lee,852,Lee,"16,828",TRUE
+South Carolina,Lexington,10736,Lexington,"298,750",TRUE
+South Carolina,Newberry,2025,Newberry,"38,440",TRUE
+South Carolina,Oconee,2969,Oconee,"79,546",TRUE
+South Carolina,Orangeburg,3640,Orangeburg,"86,175",TRUE
+South Carolina,Pickens,5732,Pickens,"126,884",TRUE
+South Carolina,Richland,19441,Richland,"415,759",TRUE
+South Carolina,Saluda,777,Saluda,"20,473",TRUE
+South Carolina,Spartanburg,11363,Spartanburg,"319,785",TRUE
+South Carolina,Sumter,4009,Sumter,"106,721",TRUE
+South Carolina,Union,976,Union,"27,316",TRUE
+South Carolina,Williamsburg,1588,Williamsburg,"30,368",TRUE
+South Carolina,York,8738,York,"280,979",TRUE
+South Dakota,Aurora,321,Aurora,"2,751",TRUE
+South Dakota,Beadle,2093,Beadle,"18,453",TRUE
+South Dakota,Bennett,293,Bennett,"3,365",TRUE
+South Dakota,Brookings,2204,Brookings,"35,077",TRUE
+South Dakota,Brown,3142,Brown,"38,839",TRUE
+South Dakota,Brule,512,Brule,"5,297",TRUE
+South Dakota,Buffalo,352,Buffalo,"1,962",TRUE
+South Dakota,Butte,642,Butte,"10,429",TRUE
+South Dakota,Campbell,97,Campbell,"1,376",TRUE
+South Dakota,Clark,218,Clark,"3,736",TRUE
+South Dakota,Clay,1198,Clay,"14,070",TRUE
+South Dakota,Codington,2403,Codington,"28,009",TRUE
+South Dakota,Corson,336,Corson,"4,086",TRUE
+South Dakota,Custer,480,Custer,"8,972",TRUE
+South Dakota,Davison,2156,Davison,"19,775",TRUE
+South Dakota,Day,297,Day,"5,424",TRUE
+South Dakota,Deuel,272,Deuel,"4,351",TRUE
+South Dakota,Dewey,720,Dewey,"5,892",TRUE
+South Dakota,Douglas,269,Douglas,"2,921",TRUE
+South Dakota,Edmunds,221,Edmunds,"3,829",TRUE
+South Dakota,Faulk,268,Faulk,"2,299",TRUE
+South Dakota,Grant,522,Grant,"7,052",TRUE
+South Dakota,Gregory,396,Gregory,"4,185",TRUE
+South Dakota,Haakon,131,Haakon,"1,899",TRUE
+South Dakota,Hamlin,403,Hamlin,"6,164",TRUE
+South Dakota,Hand,261,Hand,"3,191",TRUE
+South Dakota,Hanson,207,Hanson,"3,453",TRUE
+South Dakota,Harding,64,Harding,"1,298",TRUE
+South Dakota,Hughes,1483,Hughes,"17,526",TRUE
+South Dakota,Hutchinson,483,Hutchinson,"7,291",TRUE
+South Dakota,Hyde,109,Hyde,"1,301",TRUE
+South Dakota,Jackson,183,Jackson,"3,344",TRUE
+South Dakota,Jerauld,227,Jerauld,"2,013",TRUE
+South Dakota,Jones,53,Jones,903,TRUE
+South Dakota,Kingsbury,391,Kingsbury,"4,939",TRUE
+South Dakota,Lake,754,Lake,"12,797",TRUE
+South Dakota,Lawrence,1779,Lawrence,"25,844",TRUE
+South Dakota,Lincoln,4834,Lincoln,"61,128",TRUE
+South Dakota,Lyman,412,Lyman,"3,781",TRUE
+South Dakota,Meade,1541,Meade,"28,332",TRUE
+South Dakota,Mellette,149,Mellette,"2,061",TRUE
+South Dakota,Miner,179,Miner,"2,216",TRUE
+South Dakota,Minnehaha,18247,Minnehaha,"193,134",TRUE
+South Dakota,Moody,374,Moody,"6,576",TRUE
+South Dakota,Pennington,7608,Pennington,"113,775",TRUE
+South Dakota,Perkins,139,Perkins,"2,865",TRUE
+South Dakota,Potter,233,Potter,"2,153",TRUE
+South Dakota,Roberts,624,Roberts,"10,394",TRUE
+South Dakota,Sanborn,228,Sanborn,"2,344",TRUE
+South Dakota,Spink,504,Spink,"6,376",TRUE
+South Dakota,Stanley,207,Stanley,"3,098",TRUE
+South Dakota,Sully,82,Sully,"1,391",TRUE
+South Dakota,Todd,803,Todd,"10,177",TRUE
+South Dakota,Tripp,440,Tripp,"5,441",TRUE
+South Dakota,Turner,739,Turner,"8,384",TRUE
+South Dakota,Union,1127,Union,"15,932",TRUE
+South Dakota,Walworth,420,Walworth,"5,435",TRUE
+South Dakota,Yankton,1450,Yankton,"22,814",TRUE
+South Dakota,Ziebach,155,Ziebach,"2,756",TRUE
+Tennessee,Anderson,2589,Anderson,"76,978",TRUE
+Tennessee,Bedford,2412,Bedford,"49,713",TRUE
+Tennessee,Benton,718,Benton,"16,160",TRUE
+Tennessee,Bledsoe,1133,Bledsoe,"15,064",TRUE
+Tennessee,Blount,4900,Blount,"133,088",TRUE
+Tennessee,Bradley,4649,Bradley,"108,110",TRUE
+Tennessee,Campbell,1389,Campbell,"39,842",TRUE
+Tennessee,Cannon,666,Cannon,"14,678",TRUE
+Tennessee,Carroll,1565,Carroll,"27,767",TRUE
+Tennessee,Carter,2453,Carter,"56,391",TRUE
+Tennessee,Cheatham,1432,Cheatham,"40,667",TRUE
+Tennessee,Chester,949,Chester,"17,297",TRUE
+Tennessee,Claiborne,718,Claiborne,"31,959",TRUE
+Tennessee,Clay,519,Clay,"7,615",TRUE
+Tennessee,Cocke,1497,Cocke,"36,004",TRUE
+Tennessee,Coffee,2547,Coffee,"56,520",TRUE
+Tennessee,Crockett,1096,Crockett,"14,230",TRUE
+Tennessee,Cumberland,2328,Cumberland,"60,520",TRUE
+Tennessee,Davidson,39770,Davidson,"694,144",TRUE
+Tennessee,Dickson,2597,Dickson,"53,948",TRUE
+Tennessee,Dyer,3004,Dyer,"37,159",TRUE
+Tennessee,Fayette,2088,Fayette,"41,133",TRUE
+Tennessee,Fentress,1133,Fentress,"18,523",TRUE
+Tennessee,Franklin,1844,Franklin,"42,208",TRUE
+Tennessee,Gibson,2893,Gibson,"49,133",TRUE
+Tennessee,Giles,1311,Giles,"29,464",TRUE
+Tennessee,Grainger,860,Grainger,"23,320",TRUE
+Tennessee,Greene,2715,Greene,"69,069",TRUE
+Tennessee,Grundy,720,Grundy,"13,427",TRUE
+Tennessee,Hamblen,3163,Hamblen,"64,934",TRUE
+Tennessee,Hamilton,15382,Hamilton,"367,804",TRUE
+Tennessee,Hancock,138,Hancock,"6,620",TRUE
+Tennessee,Hardeman,2175,Hardeman,"25,050",TRUE
+Tennessee,Hardin,1680,Hardin,"25,652",TRUE
+Tennessee,Hawkins,1727,Hawkins,"56,786",TRUE
+Tennessee,Haywood,1553,Haywood,"17,304",TRUE
+Tennessee,Henderson,1736,Henderson,"28,117",TRUE
+Tennessee,Henry,1352,Henry,"32,345",TRUE
+Tennessee,Hickman,1077,Hickman,"25,178",TRUE
+Tennessee,Houston,563,Houston,"8,201",TRUE
+Tennessee,Humphreys,629,Humphreys,"18,582",TRUE
+Tennessee,Jackson,650,Jackson,"11,786",TRUE
+Tennessee,Jefferson,2057,Jefferson,"54,495",TRUE
+Tennessee,Johnson,1351,Johnson,"17,788",TRUE
+Tennessee,Knox,17026,Knox,"470,313",TRUE
+Tennessee,Lake,1132,Lake,"7,016",TRUE
+Tennessee,Lauderdale,1959,Lauderdale,"25,633",TRUE
+Tennessee,Lawrence,2430,Lawrence,"44,142",TRUE
+Tennessee,Lewis,690,Lewis,"12,268",TRUE
+Tennessee,Lincoln,1358,Lincoln,"34,366",TRUE
+Tennessee,Loudon,2084,Loudon,"54,068",TRUE
+Tennessee,Meigs,443,Meigs,"12,422",TRUE
+Tennessee,Monroe,1916,Monroe,"46,545",TRUE
+Tennessee,Montgomery,5956,Montgomery,"208,993",TRUE
+Tennessee,Moore,355,Moore,"6,488",TRUE
+Tennessee,Morgan,609,Morgan,"21,403",TRUE
+Tennessee,Obion,2440,Obion,"30,069",TRUE
+Tennessee,Overton,1473,Overton,"22,241",TRUE
+Tennessee,Perry,452,Perry,"8,076",TRUE
+Tennessee,Pickett,359,Pickett,"5,048",TRUE
+Tennessee,Polk,614,Polk,"16,832",TRUE
+Tennessee,Putnam,5567,Putnam,"80,245",TRUE
+Tennessee,Rhea,1498,Rhea,"33,167",TRUE
+Tennessee,Roane,2116,Roane,"53,382",TRUE
+Tennessee,Robertson,3415,Robertson,"71,813",TRUE
+Tennessee,Rutherford,16264,Rutherford,"332,285",TRUE
+Tennessee,Scott,875,Scott,"22,068",TRUE
+Tennessee,Sequatchie,484,Sequatchie,"15,026",TRUE
+Tennessee,Sevier,4419,Sevier,"98,250",TRUE
+Tennessee,Shelby,44615,Shelby,"937,166",TRUE
+Tennessee,Smith,1338,Smith,"20,157",TRUE
+Tennessee,Stewart,535,Stewart,"13,715",TRUE
+Tennessee,Sullivan,5755,Sullivan,"158,348",TRUE
+Tennessee,Sumner,8696,Sumner,"191,283",TRUE
+Tennessee,Tipton,3294,Tipton,"61,599",TRUE
+Tennessee,Trousdale,1885,Trousdale,"11,284",TRUE
+Tennessee,Unicoi,728,Unicoi,"17,883",TRUE
+Tennessee,Union,669,Union,"19,972",TRUE
+Tennessee,Warren,2166,Warren,"41,277",TRUE
+Tennessee,Washington,5338,Washington,"129,375",TRUE
+Tennessee,Wayne,1764,Wayne,"16,673",TRUE
+Tennessee,Weakley,2024,Weakley,"33,328",TRUE
+Tennessee,White,1632,White,"27,345",TRUE
+Tennessee,Williamson,10231,Williamson,"238,412",TRUE
+Tennessee,Wilson,6681,Wilson,"144,657",TRUE
+Texas,Anderson,3092,Anderson,"57,735",TRUE
+Texas,Andrews,940,Andrews,"18,705",TRUE
+Texas,Angelina,2515,Angelina,"86,715",TRUE
+Texas,Aransas,376,Aransas,"23,510",TRUE
+Texas,Archer,227,Archer,"8,553",TRUE
+Texas,Armstrong,39,Armstrong,"1,887",TRUE
+Texas,Atascosa,1418,Atascosa,"51,153",TRUE
+Texas,Austin,554,Austin,"30,032",TRUE
+Texas,Bailey,439,Bailey,"7,000",TRUE
+Texas,Bandera,219,Bandera,"23,112",TRUE
+Texas,Bastrop,2198,Bastrop,"88,723",TRUE
+Texas,Baylor,52,Baylor,"3,509",TRUE
+Texas,Bee,1943,Bee,"32,565",TRUE
+Texas,Bell,7911,Bell,"362,924",TRUE
+Texas,Bexar,72313,Bexar,"2,003,554",TRUE
+Texas,Blanco,176,Blanco,"11,931",TRUE
+Texas,Borden,4,Borden,654,TRUE
+Texas,Bosque,507,Bosque,"18,685",TRUE
+Texas,Bowie,2406,Bowie,"93,245",TRUE
+Texas,Brazoria,13626,Brazoria,"374,264",TRUE
+Texas,Brazos,8944,Brazos,"229,211",TRUE
+Texas,Brewster,427,Brewster,"9,203",TRUE
+Texas,Briscoe,39,Briscoe,"1,546",TRUE
+Texas,Brooks,388,Brooks,"7,093",TRUE
+Texas,Brown,875,Brown,"37,864",TRUE
+Texas,Burleson,617,Burleson,"18,443",TRUE
+Texas,Burnet,1303,Burnet,"48,155",TRUE
+Texas,Caldwell,1813,Caldwell,"43,664",TRUE
+Texas,Calhoun,968,Calhoun,"21,290",TRUE
+Texas,Callahan,196,Callahan,"13,943",TRUE
+Texas,Cameron,25396,Cameron,"423,163",TRUE
+Texas,Camp,441,Camp,"13,094",TRUE
+Texas,Carson,86,Carson,"5,926",TRUE
+Texas,Cass,716,Cass,"30,026",TRUE
+Texas,Castro,427,Castro,"7,530",TRUE
+Texas,Chambers,1845,Chambers,"43,837",TRUE
+Texas,Cherokee,1717,Cherokee,"52,646",TRUE
+Texas,Childress,810,Childress,"7,306",TRUE
+Texas,Clay,239,Clay,"10,471",TRUE
+Texas,Cochran,148,Cochran,"2,853",TRUE
+Texas,Coke,161,Coke,"3,387",TRUE
+Texas,Coleman,172,Coleman,"8,175",TRUE
+Texas,Collin,22369,Collin,"1,034,730",TRUE
+Texas,Collingsworth,38,Collingsworth,"2,920",TRUE
+Texas,Colorado,559,Colorado,"21,493",TRUE
+Texas,Comal,3079,Comal,"156,209",TRUE
+Texas,Comanche,416,Comanche,"13,635",TRUE
+Texas,Concho,180,Concho,"2,726",TRUE
+Texas,Cooke,713,Cooke,"41,257",TRUE
+Texas,Coryell,2281,Coryell,"75,951",TRUE
+Texas,Cottle,52,Cottle,"1,398",TRUE
+Texas,Crane,159,Crane,"4,797",TRUE
+Texas,Crockett,210,Crockett,"3,464",TRUE
+Texas,Crosby,163,Crosby,"5,737",TRUE
+Texas,Culberson,175,Culberson,"2,171",TRUE
+Texas,Dallam,426,Dallam,"7,287",TRUE
+Texas,Dallas,115410,Dallas,"2,635,516",TRUE
+Texas,Dawson,1141,Dawson,"12,728",TRUE
+Texas,Dickens,64,Dickens,"2,211",TRUE
+Texas,Dimmit,341,Dimmit,"10,124",TRUE
+Texas,Donley,107,Donley,"3,278",TRUE
+Texas,Duval,561,Duval,"11,157",TRUE
+Texas,Eastland,336,Eastland,"18,360",TRUE
+Texas,Ector,8206,Ector,"166,223",TRUE
+Texas,Edwards,81,Edwards,"1,932",TRUE
+Texas,Erath,1243,Erath,"42,698",TRUE
+Texas,Falls,748,Falls,"17,297",TRUE
+Texas,Fannin,930,Fannin,"35,514",TRUE
+Texas,Fayette,751,Fayette,"25,346",TRUE
+Texas,Fisher,145,Fisher,"3,830",TRUE
+Texas,Floyd,179,Floyd,"5,712",TRUE
+Texas,Foard,25,Foard,"1,155",TRUE
+Texas,Franklin,245,Franklin,"10,725",TRUE
+Texas,Freestone,493,Freestone,"19,717",TRUE
+Texas,Frio,1082,Frio,"20,306",TRUE
+Texas,Gaines,856,Gaines,"21,492",TRUE
+Texas,Galveston,13922,Galveston,"342,139",TRUE
+Texas,Garza,159,Garza,"6,229",TRUE
+Texas,Gillespie,439,Gillespie,"26,988",TRUE
+Texas,Glasscock,30,Glasscock,"1,409",TRUE
+Texas,Goliad,177,Goliad,"7,658",TRUE
+Texas,Gonzales,1205,Gonzales,"20,837",TRUE
+Texas,Gray,1196,Gray,"21,886",TRUE
+Texas,Grayson,3818,Grayson,"136,212",TRUE
+Texas,Gregg,3070,Gregg,"123,945",TRUE
+Texas,Grimes,1314,Grimes,"28,880",TRUE
+Texas,Guadalupe,4131,Guadalupe,"166,847",TRUE
+Texas,Hale,3742,Hale,"33,406",TRUE
+Texas,Hall,76,Hall,"2,964",TRUE
+Texas,Hamilton,275,Hamilton,"8,461",TRUE
+Texas,Hansford,226,Hansford,"5,399",TRUE
+Texas,Hardeman,77,Hardeman,"3,933",TRUE
+Texas,Hardin,1560,Hardin,"57,602",TRUE
+Texas,Harris,179911,Harris,"4,713,325",TRUE
+Texas,Harrison,1215,Harrison,"66,553",TRUE
+Texas,Hartley,200,Hartley,"5,576",TRUE
+Texas,Haskell,94,Haskell,"5,658",TRUE
+Texas,Hays,6960,Hays,"230,191",TRUE
+Texas,Hemphill,232,Hemphill,"3,819",TRUE
+Texas,Henderson,1682,Henderson,"82,737",TRUE
+Texas,Hidalgo,40085,Hidalgo,"868,707",TRUE
+Texas,Hill,1101,Hill,"36,649",TRUE
+Texas,Hockley,1203,Hockley,"23,021",TRUE
+Texas,Hood,1455,Hood,"61,643",TRUE
+Texas,Hopkins,790,Hopkins,"37,084",TRUE
+Texas,Houston,506,Houston,"22,968",TRUE
+Texas,Howard,1619,Howard,"36,664",TRUE
+Texas,Hudspeth,164,Hudspeth,"4,886",TRUE
+Texas,Hunt,2528,Hunt,"98,594",TRUE
+Texas,Hutchinson,594,Hutchinson,"20,938",TRUE
+Texas,Irion,16,Irion,"1,536",TRUE
+Texas,Jack,214,Jack,"8,935",TRUE
+Texas,Jackson,762,Jackson,"14,760",TRUE
+Texas,Jasper,537,Jasper,"35,529",TRUE
+Texas,Jefferson,9728,Jefferson,"251,565",TRUE
+Texas,Johnson,4788,Johnson,"175,817",TRUE
+Texas,Jones,1593,Jones,"20,083",TRUE
+Texas,Karnes,986,Karnes,"15,601",TRUE
+Texas,Kaufman,4286,Kaufman,"136,154",TRUE
+Texas,Kendall,476,Kendall,"47,431",TRUE
+Texas,Kenedy,11,Kenedy,404,TRUE
+Texas,Kent,21,Kent,762,TRUE
+Texas,Kerr,848,Kerr,"52,600",TRUE
+Texas,Kimble,79,Kimble,"4,337",TRUE
+Texas,King,1,King,272,TRUE
+Texas,Kinney,85,Kinney,"3,667",TRUE
+Texas,Kleberg,1129,Kleberg,"30,680",TRUE
+Texas,Knox,117,Knox,"3,664",TRUE
+Texas,Lavaca,1332,Lavaca,"20,154",TRUE
+Texas,Lee,273,Lee,"17,239",TRUE
+Texas,Leon,425,Leon,"17,404",TRUE
+Texas,Liberty,2399,Liberty,"88,219",TRUE
+Texas,Limestone,752,Limestone,"23,437",TRUE
+Texas,Lipscomb,117,Lipscomb,"3,233",TRUE
+Texas,Llano,259,Llano,"21,795",TRUE
+Texas,Loving,1,Loving,169,TRUE
+Texas,Lubbock,27660,Lubbock,"310,569",TRUE
+Texas,Lynn,301,Lynn,"5,951",TRUE
+Texas,Medina,1359,Medina,"51,584",TRUE
+Texas,Menard,103,Menard,"2,138",TRUE
+Texas,Midland,6576,Midland,"176,832",TRUE
+Texas,Milam,609,Milam,"24,823",TRUE
+Texas,Mills,128,Mills,"4,873",TRUE
+Texas,Mitchell,280,Mitchell,"8,545",TRUE
+Texas,Montague,502,Montague,"19,818",TRUE
+Texas,Montgomery,15920,Montgomery,"607,391",TRUE
+Texas,Moore,1537,Moore,"20,940",TRUE
+Texas,Morris,261,Morris,"12,388",TRUE
+Texas,Motley,19,Motley,"1,200",TRUE
+Texas,Nacogdoches,1915,Nacogdoches,"65,204",TRUE
+Texas,Navarro,1696,Navarro,"50,113",TRUE
+Texas,Newton,195,Newton,"13,595",TRUE
+Texas,Nolan,633,Nolan,"14,714",TRUE
+Texas,Nueces,22942,Nueces,"362,294",TRUE
+Texas,Ochiltree,487,Ochiltree,"9,836",TRUE
+Texas,Oldham,33,Oldham,"2,112",TRUE
+Texas,Orange,2491,Orange,"83,396",TRUE
+Texas,Panola,522,Panola,"23,194",TRUE
+Texas,Parker,3365,Parker,"142,878",TRUE
+Texas,Parmer,669,Parmer,"9,605",TRUE
+Texas,Pecos,687,Pecos,"15,823",TRUE
+Texas,Polk,991,Polk,"51,353",TRUE
+Texas,Potter,11521,Potter,"117,415",TRUE
+Texas,Presidio,270,Presidio,"6,704",TRUE
+Texas,Rains,152,Rains,"12,514",TRUE
+Texas,Randall,9040,Randall,"137,713",TRUE
+Texas,Reagan,159,Reagan,"3,849",TRUE
+Texas,Real,130,Real,"3,452",TRUE
+Texas,Reeves,466,Reeves,"15,976",TRUE
+Texas,Refugio,333,Refugio,"6,948",TRUE
+Texas,Roberts,24,Roberts,854,TRUE
+Texas,Robertson,469,Robertson,"17,074",TRUE
+Texas,Rockwall,2511,Rockwall,"104,915",TRUE
+Texas,Runnels,332,Runnels,"10,264",TRUE
+Texas,Rusk,1161,Rusk,"54,406",TRUE
+Texas,Sabine,120,Sabine,"10,542",TRUE
+Texas,Schleicher,105,Schleicher,"2,793",TRUE
+Texas,Scurry,1449,Scurry,"16,703",TRUE
+Texas,Shackelford,46,Shackelford,"3,265",TRUE
+Texas,Shelby,589,Shelby,"25,274",TRUE
+Texas,Sherman,86,Sherman,"3,022",TRUE
+Texas,Smith,5604,Smith,"232,751",TRUE
+Texas,Somervell,225,Somervell,"9,128",TRUE
+Texas,Starr,3784,Starr,"64,633",TRUE
+Texas,Stephens,225,Stephens,"9,366",TRUE
+Texas,Sterling,33,Sterling,"1,291",TRUE
+Texas,Stonewall,24,Stonewall,"1,350",TRUE
+Texas,Sutton,179,Sutton,"3,776",TRUE
+Texas,Swisher,227,Swisher,"7,397",TRUE
+Texas,Tarrant,88948,Tarrant,"2,102,515",TRUE
+Texas,Taylor,3015,Taylor,"138,034",TRUE
+Texas,Terrell,13,Terrell,776,TRUE
+Texas,Terry,882,Terry,"12,337",TRUE
+Texas,Throckmorton,23,Throckmorton,"1,501",TRUE
+Texas,Titus,1831,Titus,"32,750",TRUE
+Texas,Travis,35984,Travis,"1,273,954",TRUE
+Texas,Trinity,225,Trinity,"14,651",TRUE
+Texas,Tyler,295,Tyler,"21,672",TRUE
+Texas,Upshur,587,Upshur,"41,753",TRUE
+Texas,Upton,42,Upton,"3,657",TRUE
+Texas,Uvalde,1029,Uvalde,"26,741",TRUE
+Texas,Victoria,4761,Victoria,"92,084",TRUE
+Texas,Walker,4076,Walker,"72,971",TRUE
+Texas,Waller,1077,Waller,"55,246",TRUE
+Texas,Ward,310,Ward,"11,998",TRUE
+Texas,Washington,907,Washington,"35,882",TRUE
+Texas,Webb,18109,Webb,"276,652",TRUE
+Texas,Wharton,1554,Wharton,"41,556",TRUE
+Texas,Wheeler,203,Wheeler,"5,056",TRUE
+Texas,Wichita,6023,Wichita,"132,230",TRUE
+Texas,Wilbarger,575,Wilbarger,"12,769",TRUE
+Texas,Willacy,1314,Willacy,"21,358",TRUE
+Texas,Williamson,11559,Williamson,"590,551",TRUE
+Texas,Wilson,1079,Wilson,"51,070",TRUE
+Texas,Winkler,257,Winkler,"8,010",TRUE
+Texas,Wise,1402,Wise,"69,984",TRUE
+Texas,Wood,846,Wood,"45,539",TRUE
+Texas,Yoakum,568,Yoakum,"8,713",TRUE
+Texas,Young,790,Young,"18,010",TRUE
+Texas,Zapata,427,Zapata,"14,179",TRUE
+Texas,Zavala,551,Zavala,"11,840",TRUE
+Utah,Beaver,0,Beaver,"6,710",TRUE
+Utah,Cache,0,Cache,"128,289",TRUE
+Utah,Carbon,0,Carbon,"20,463",TRUE
+Utah,Daggett,0,Daggett,950,TRUE
+Utah,Davis,14114,Davis,"355,481",TRUE
+Utah,Duchesne,0,Duchesne,"19,938",TRUE
+Utah,Emery,0,Emery,"10,012",TRUE
+Utah,Garfield,0,Garfield,"5,051",TRUE
+Utah,Grand,0,Grand,"9,754",TRUE
+Utah,Iron,0,Iron,"54,839",TRUE
+Utah,Juab,0,Juab,"12,017",TRUE
+Utah,Kane,0,Kane,"7,886",TRUE
+Utah,Millard,0,Millard,"13,188",TRUE
+Utah,Morgan,0,Morgan,"12,124",TRUE
+Utah,Piute,0,Piute,"1,479",TRUE
+Utah,Rich,0,Rich,"2,483",TRUE
+Utah,Sanpete,0,Sanpete,"30,939",TRUE
+Utah,Sevier,0,Sevier,"21,620",TRUE
+Utah,Summit,2018,Summit,"42,145",TRUE
+Utah,Tooele,2516,Tooele,"72,259",TRUE
+Utah,Uintah,1195,Uintah,"35,734",TRUE
+Utah,Utah,43201,Utah,"636,235",TRUE
+Utah,Wasatch,1808,Wasatch,"34,091",TRUE
+Utah,Washington,13690,Washington,"177,556",TRUE
+Utah,Wayne,0,Wayne,"2,711",TRUE
+Utah,Weber,11350,Weber,"260,213",TRUE
+Vermont,Addison,157,Addison,"36,777",TRUE
+Vermont,Bennington,181,Bennington,"35,470",TRUE
+Vermont,Caledonia,92,Caledonia,"29,993",TRUE
+Vermont,Chittenden,1330,Chittenden,"163,774",TRUE
+Vermont,Essex,26,Essex,"6,163",TRUE
+Vermont,Franklin,187,Franklin,"49,402",TRUE
+Vermont,Lamoille,125,Lamoille,"25,362",TRUE
+Vermont,Orange,159,Orange,"28,892",TRUE
+Vermont,Orleans,99,Orleans,"27,037",TRUE
+Vermont,Rutland,205,Rutland,"58,191",TRUE
+Vermont,Washington,501,Washington,"58,409",TRUE
+Vermont,Windham,190,Windham,"42,222",TRUE
+Vermont,Windsor,163,Windsor,"55,062",TRUE
+Virginia,Accomack,1282,Accomack,"32,316",TRUE
+Virginia,Albemarle,1767,Albemarle,"109,330",TRUE
+Virginia,Alleghany,262,Alleghany,"14,860",TRUE
+Virginia,Amelia,170,Amelia,"13,145",TRUE
+Virginia,Amherst,710,Amherst,"31,605",TRUE
+Virginia,Appomattox,371,Appomattox,"15,911",TRUE
+Virginia,Arlington,5603,Arlington,"236,842",TRUE
+Virginia,Augusta,985,Augusta,"75,558",TRUE
+Virginia,Bath,48,Bath,"4,147",TRUE
+Virginia,Bedford,1660,Bedford,"78,997",TRUE
+Virginia,Bland,113,Bland,"6,280",TRUE
+Virginia,Botetourt,676,Botetourt,"33,419",TRUE
+Virginia,Brunswick,454,Brunswick,"16,231",TRUE
+Virginia,Buchanan,359,Buchanan,"21,004",TRUE
+Virginia,Buckingham,838,Buckingham,"17,148",TRUE
+Virginia,Campbell,1006,Campbell,"54,885",TRUE
+Virginia,Caroline,531,Caroline,"30,725",TRUE
+Virginia,Carroll,822,Carroll,"29,791",TRUE
+Virginia,Charlotte,266,Charlotte,"11,880",TRUE
+Virginia,Chesterfield,8451,Chesterfield,"352,802",TRUE
+Virginia,Clarke,178,Clarke,"14,619",TRUE
+Virginia,Craig,79,Craig,"5,131",TRUE
+Virginia,Culpeper,1866,Culpeper,"52,605",TRUE
+Virginia,Cumberland,141,Cumberland,"9,932",TRUE
+Virginia,Dickenson,233,Dickenson,"14,318",TRUE
+Virginia,Dinwiddie,618,Dinwiddie,"28,544",TRUE
+Virginia,Essex,223,Essex,"10,953",TRUE
+Virginia,Fairfax,27732,Fairfax,"1,147,532",TRUE
+Virginia,Fauquier,1332,Fauquier,"71,222",TRUE
+Virginia,Floyd,303,Floyd,"15,749",TRUE
+Virginia,Fluvanna,471,Fluvanna,"27,270",TRUE
+Virginia,Franklin,1374,Franklin,"56,042",TRUE
+Virginia,Frederick,1741,Frederick,"89,313",TRUE
+Virginia,Giles,223,Giles,"16,720",TRUE
+Virginia,Gloucester,391,Gloucester,"37,348",TRUE
+Virginia,Goochland,389,Goochland,"23,753",TRUE
+Virginia,Grayson,477,Grayson,"15,550",TRUE
+Virginia,Greene,340,Greene,"19,819",TRUE
+Virginia,Greensville,925,Greensville,"11,336",TRUE
+Virginia,Halifax,758,Halifax,"33,911",TRUE
+Virginia,Hanover,2139,Hanover,"107,766",TRUE
+Virginia,Henrico,7604,Henrico,"330,818",TRUE
+Virginia,Henry,1688,Henry,"50,557",TRUE
+Virginia,Highland,14,Highland,"2,190",TRUE
+Virginia,Lancaster,224,Lancaster,"10,603",TRUE
+Virginia,Lee,783,Lee,"23,423",TRUE
+Virginia,Loudoun,9149,Loudoun,"413,538",TRUE
+Virginia,Louisa,464,Louisa,"37,591",TRUE
+Virginia,Lunenburg,163,Lunenburg,"12,196",TRUE
+Virginia,Madison,171,Madison,"13,261",TRUE
+Virginia,Mathews,151,Mathews,"8,834",TRUE
+Virginia,Mecklenburg,962,Mecklenburg,"30,587",TRUE
+Virginia,Middlesex,152,Middlesex,"10,582",TRUE
+Virginia,Montgomery,3581,Montgomery,"98,535",TRUE
+Virginia,Nelson,159,Nelson,"14,930",TRUE
+Virginia,Northampton,335,Northampton,"11,710",TRUE
+Virginia,Northumberland,246,Northumberland,"12,095",TRUE
+Virginia,Nottoway,475,Nottoway,"15,232",TRUE
+Virginia,Orange,515,Orange,"37,051",TRUE
+Virginia,Page,549,Page,"23,902",TRUE
+Virginia,Patrick,415,Patrick,"17,608",TRUE
+Virginia,Pittsylvania,1565,Pittsylvania,"60,354",TRUE
+Virginia,Powhatan,391,Powhatan,"29,652",TRUE
+Virginia,Pulaski,505,Pulaski,"34,027",TRUE
+Virginia,Rappahannock,75,Rappahannock,"7,370",TRUE
+Virginia,Richmond,380,Richmond,"9,023",TRUE
+Virginia,Roanoke,2460,Roanoke,"94,186",TRUE
+Virginia,Rockbridge,214,Rockbridge,"22,573",TRUE
+Virginia,Rockingham,2063,Rockingham,"81,948",TRUE
+Virginia,Russell,733,Russell,"26,586",TRUE
+Virginia,Scott,672,Scott,"21,566",TRUE
+Virginia,Shenandoah,1268,Shenandoah,"43,616",TRUE
+Virginia,Smyth,898,Smyth,"30,104",TRUE
+Virginia,Southampton,962,Southampton,"17,631",TRUE
+Virginia,Spotsylvania,2860,Spotsylvania,"136,215",TRUE
+Virginia,Stafford,2922,Stafford,"152,882",TRUE
+Virginia,Surry,154,Surry,"6,422",TRUE
+Virginia,Sussex,658,Sussex,"11,159",TRUE
+Virginia,Tazewell,878,Tazewell,"40,595",TRUE
+Virginia,Warren,746,Warren,"40,164",TRUE
+Virginia,Washington,1544,Washington,"53,740",TRUE
+Virginia,Westmoreland,393,Westmoreland,"18,015",TRUE
+Virginia,Wise,1097,Wise,"37,383",TRUE
+Virginia,Wythe,530,Wythe,"28,684",TRUE
+Virginia,York,806,York,"68,280",TRUE
+Washington,Adams,1232,Adams,"19,983",TRUE
+Washington,Asotin,535,Asotin,"22,582",TRUE
+Washington,Benton,6996,Benton,"204,390",TRUE
+Washington,Chelan,2201,Chelan,"77,200",TRUE
+Washington,Clallam,362,Clallam,"77,331",TRUE
+Washington,Clark,7093,Clark,"488,241",TRUE
+Washington,Columbia,27,Columbia,"3,985",TRUE
+Washington,Cowlitz,1132,Cowlitz,"110,593",TRUE
+Washington,Douglas,1290,Douglas,"43,429",TRUE
+Washington,Ferry,48,Ferry,"7,627",TRUE
+Washington,Franklin,5753,Franklin,"95,222",TRUE
+Washington,Garfield,52,Garfield,"2,225",TRUE
+Washington,Grant,3754,Grant,"97,733",TRUE
+Washington,Island,536,Island,"85,141",TRUE
+Washington,Jefferson,134,Jefferson,"32,221",TRUE
+Washington,King,37113,King,"2,252,782",TRUE
+Washington,Kitsap,2100,Kitsap,"271,473",TRUE
+Washington,Kittitas,851,Kittitas,"47,935",TRUE
+Washington,Klickitat,239,Klickitat,"22,425",TRUE
+Washington,Lewis,997,Lewis,"80,707",TRUE
+Washington,Lincoln,127,Lincoln,"10,939",TRUE
+Washington,Mason,649,Mason,"66,768",TRUE
+Washington,Okanogan,1174,Okanogan,"42,243",TRUE
+Washington,Pacific,190,Pacific,"22,471",TRUE
+Washington,Pierce,14093,Pierce,"904,980",TRUE
+Washington,Skagit,1711,Skagit,"129,205",TRUE
+Washington,Skamania,87,Skamania,"12,083",TRUE
+Washington,Snohomish,12173,Snohomish,"822,083",TRUE
+Washington,Spokane,13523,Spokane,"522,798",TRUE
+Washington,Stevens,479,Stevens,"45,723",TRUE
+Washington,Thurston,2494,Thurston,"290,536",TRUE
+Washington,Wahkiakum,14,Wahkiakum,"4,488",TRUE
+Washington,Whatcom,2002,Whatcom,"229,247",TRUE
+Washington,Whitman,2150,Whitman,"50,104",TRUE
+Washington,Yakima,12747,Yakima,"250,873",TRUE
+West Virginia,Barbour,312,Barbour,"16,441",TRUE
+West Virginia,Berkeley,2544,Berkeley,"119,171",TRUE
+West Virginia,Boone,559,Boone,"21,457",TRUE
+West Virginia,Braxton,99,Braxton,"13,957",TRUE
+West Virginia,Brooke,483,Brooke,"21,939",TRUE
+West Virginia,Cabell,2421,Cabell,"91,945",TRUE
+West Virginia,Calhoun,53,Calhoun,"7,109",TRUE
+West Virginia,Clay,104,Clay,"8,508",TRUE
+West Virginia,Doddridge,98,Doddridge,"8,448",TRUE
+West Virginia,Fayette,1023,Fayette,"42,406",TRUE
+West Virginia,Gilmer,180,Gilmer,"7,823",TRUE
+West Virginia,Grant,267,Grant,"11,568",TRUE
+West Virginia,Greenbrier,361,Greenbrier,"34,662",TRUE
+West Virginia,Hampshire,246,Hampshire,"23,175",TRUE
+West Virginia,Hancock,474,Hancock,"28,810",TRUE
+West Virginia,Hardy,181,Hardy,"13,776",TRUE
+West Virginia,Harrison,1019,Harrison,"67,256",TRUE
+West Virginia,Jackson,636,Jackson,"28,576",TRUE
+West Virginia,Jefferson,1093,Jefferson,"57,146",TRUE
+West Virginia,Kanawha,5024,Kanawha,"178,124",TRUE
+West Virginia,Lewis,219,Lewis,"15,907",TRUE
+West Virginia,Lincoln,375,Lincoln,"20,409",TRUE
+West Virginia,Logan,965,Logan,"32,019",TRUE
+West Virginia,Mercer,1163,Mercer,"58,758",TRUE
+West Virginia,Mineral,798,Mineral,"26,868",TRUE
+West Virginia,Mingo,889,Mingo,"23,424",TRUE
+West Virginia,Monongalia,2948,Monongalia,"105,612",TRUE
+West Virginia,Monroe,321,Monroe,"13,275",TRUE
+West Virginia,Morgan,226,Morgan,"17,884",TRUE
+West Virginia,Nicholas,291,Nicholas,"24,496",TRUE
+West Virginia,Ohio,1219,Ohio,"41,411",TRUE
+West Virginia,Pendleton,90,Pendleton,"6,969",TRUE
+West Virginia,Pleasants,66,Pleasants,"7,460",TRUE
+West Virginia,Pocahontas,89,Pocahontas,"8,247",TRUE
+West Virginia,Preston,420,Preston,"33,432",TRUE
+West Virginia,Putnam,1550,Putnam,"56,450",TRUE
+West Virginia,Raleigh,1333,Raleigh,"73,361",TRUE
+West Virginia,Randolph,599,Randolph,"28,695",TRUE
+West Virginia,Ritchie,107,Ritchie,"9,554",TRUE
+West Virginia,Roane,144,Roane,"13,688",TRUE
+West Virginia,Summers,242,Summers,"12,573",TRUE
+West Virginia,Taylor,246,Taylor,"16,695",TRUE
+West Virginia,Tucker,98,Tucker,"6,839",TRUE
+West Virginia,Tyler,116,Tyler,"8,591",TRUE
+West Virginia,Upshur,410,Upshur,"24,176",TRUE
+West Virginia,Wayne,871,Wayne,"39,402",TRUE
+West Virginia,Webster,51,Webster,"8,114",TRUE
+West Virginia,Wetzel,352,Wetzel,"15,065",TRUE
+West Virginia,Wirt,77,Wirt,"5,821",TRUE
+West Virginia,Wood,1950,Wood,"83,518",TRUE
+West Virginia,Wyoming,584,Wyoming,"20,394",TRUE
+Wisconsin,Adams,1006,Adams,"20,220",TRUE
+Wisconsin,Ashland,584,Ashland,"15,562",TRUE
+Wisconsin,Barron,3186,Barron,"45,244",TRUE
+Wisconsin,Bayfield,613,Bayfield,"15,036",TRUE
+Wisconsin,Brown,21354,Brown,"264,542",TRUE
+Wisconsin,Buffalo,691,Buffalo,"13,031",TRUE
+Wisconsin,Burnett,689,Burnett,"15,414",TRUE
+Wisconsin,Calumet,3942,Calumet,"50,089",TRUE
+Wisconsin,Chippewa,4009,Chippewa,"64,658",TRUE
+Wisconsin,Clark,2015,Clark,"34,774",TRUE
+Wisconsin,Columbia,3194,Columbia,"57,532",TRUE
+Wisconsin,Crawford,797,Crawford,"16,131",TRUE
+Wisconsin,Dane,24973,Dane,"546,695",TRUE
+Wisconsin,Dodge,7813,Dodge,"87,839",TRUE
+Wisconsin,Door,1593,Door,"27,668",TRUE
+Wisconsin,Douglas,1628,Douglas,"43,150",TRUE
+Wisconsin,Dunn,2365,Dunn,"45,368",TRUE
+Wisconsin,Florence,309,Florence,"4,295",TRUE
+Wisconsin,Forest,725,Forest,"9,004",TRUE
+Wisconsin,Grant,3310,Grant,"51,439",TRUE
+Wisconsin,Green,1522,Green,"36,960",TRUE
+Wisconsin,Iowa,1175,Iowa,"23,678",TRUE
+Wisconsin,Iron,380,Iron,"5,687",TRUE
+Wisconsin,Jackson,1447,Jackson,"20,643",TRUE
+Wisconsin,Jefferson,5013,Jefferson,"84,769",TRUE
+Wisconsin,Juneau,1721,Juneau,"26,687",TRUE
+Wisconsin,Kenosha,9140,Kenosha,"169,561",TRUE
+Wisconsin,Kewaunee,1569,Kewaunee,"20,434",TRUE
+Wisconsin,Lafayette,1017,Lafayette,"16,665",TRUE
+Wisconsin,Langlade,1497,Langlade,"19,189",TRUE
+Wisconsin,Lincoln,1776,Lincoln,"27,593",TRUE
+Wisconsin,Manitowoc,4967,Manitowoc,"78,981",TRUE
+Wisconsin,Marathon,9406,Marathon,"135,692",TRUE
+Wisconsin,Marinette,2889,Marinette,"40,350",TRUE
+Wisconsin,Marquette,1092,Marquette,"15,574",TRUE
+Wisconsin,Menominee,533,Menominee,"4,556",TRUE
+Wisconsin,Milwaukee,64259,Milwaukee,"945,726",TRUE
+Wisconsin,Monroe,2217,Monroe,"46,253",TRUE
+Wisconsin,Oconto,3146,Oconto,"37,930",TRUE
+Wisconsin,Oneida,2138,Oneida,"35,595",TRUE
+Wisconsin,Outagamie,13475,Outagamie,"187,885",TRUE
+Wisconsin,Ozaukee,4693,Ozaukee,"89,221",TRUE
+Wisconsin,Pepin,418,Pepin,"7,287",TRUE
+Wisconsin,Pierce,2106,Pierce,"42,754",TRUE
+Wisconsin,Polk,1799,Polk,"43,783",TRUE
+Wisconsin,Portage,4429,Portage,"70,772",TRUE
+Wisconsin,Price,668,Price,"13,351",TRUE
+Wisconsin,Racine,13838,Racine,"196,311",TRUE
+Wisconsin,Richland,785,Richland,"17,252",TRUE
+Wisconsin,Rock,8554,Rock,"163,354",TRUE
+Wisconsin,Rusk,723,Rusk,"14,178",TRUE
+Wisconsin,Taylor,1095,Taylor,"20,343",TRUE
+Wisconsin,Trempealeau,2091,Trempealeau,"29,649",TRUE
+Wisconsin,Vernon,945,Vernon,"30,822",TRUE
+Wisconsin,Vilas,1100,Vilas,"22,195",TRUE
+Wisconsin,Walworth,6105,Walworth,"103,868",TRUE
+Wisconsin,Washburn,572,Washburn,"15,720",TRUE
+Wisconsin,Washington,8504,Washington,"136,034",TRUE
+Wisconsin,Waukesha,25013,Waukesha,"404,198",TRUE
+Wisconsin,Waupaca,3871,Waupaca,"50,990",TRUE
+Wisconsin,Waushara,1713,Waushara,"24,443",TRUE
+Wisconsin,Winnebago,13287,Winnebago,"171,907",TRUE
+Wisconsin,Wood,3884,Wood,"72,999",TRUE
+Wyoming,Albany,2817,Albany,"38,880",TRUE
+Wyoming,Campbell,2470,Campbell,"46,341",TRUE
+Wyoming,Carbon,556,Carbon,"14,800",TRUE
+Wyoming,Converse,535,Converse,"13,822",TRUE
+Wyoming,Crook,272,Crook,"7,584",TRUE
+Wyoming,Fremont,2827,Fremont,"39,261",TRUE
+Wyoming,Goshen,505,Goshen,"13,211",TRUE
+Wyoming,Johnson,251,Johnson,"8,445",TRUE
+Wyoming,Laramie,4006,Laramie,"99,500",TRUE
+Wyoming,Lincoln,567,Lincoln,"19,830",TRUE
+Wyoming,Natrona,4082,Natrona,"79,858",TRUE
+Wyoming,Niobrara,88,Niobrara,"2,356",TRUE
+Wyoming,Park,1158,Park,"29,194",TRUE
+Wyoming,Platte,282,Platte,"8,393",TRUE
+Wyoming,Sheridan,1592,Sheridan,"30,485",TRUE
+Wyoming,Sublette,349,Sublette,"9,831",TRUE
+Wyoming,Sweetwater,1353,Sweetwater,"42,343",TRUE
+Wyoming,Teton,1336,Teton,"23,464",TRUE
+Wyoming,Uinta,894,Uinta,"20,226",TRUE
+Wyoming,Washakie,290,Washakie,"7,805",TRUE
+Wyoming,Weston,364,Weston,"6,927",TRUE


### PR DESCRIPTION
added a new line that compares county name of case data to county name of population data. if you use filter you can find where the values are false and switch things around. also got rid of a lot of "not matching" cases by adding spaces in the names of counties and making the names match when they were already the same county but there were just some small errors with name formatting. 